### PR TITLE
Fixed bug when big wireguard dumps (~1000+ peers) breaks wirerest

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ ___
 - Authorization key rate limits & scopes 
 - Sort peers by key, ip, received, sent, last handshake etc. 
 - Callback API 
+- Caching 

--- a/src/main/java/com/wireguard/external/shell/ShellRunner.java
+++ b/src/main/java/com/wireguard/external/shell/ShellRunner.java
@@ -28,9 +28,7 @@ public class ShellRunner {
     public String execute(String[] command, List<Integer> allowedExitCodes) {
         Process process = startProcess(command);
         int exitCode = waitForProcess(process);
-        System.out.println("redirecting stdout");
         String stdout = readInputStream(process.getInputStream());
-        System.out.println("redirecting stderr");
         String stderr = readInputStream(process.getErrorStream());
         if (!allowedExitCodes.contains(exitCode)) {
             throw new CommandExecutionException(String.join(" ", command), exitCode, stdout, stderr);
@@ -42,7 +40,7 @@ public class ShellRunner {
         return execute(command, List.of(0));
     }
 
-    private Process startProcess(String[] command) {
+    public Process startProcess(String[] command) {
         String stringCommand = String.join(" ", command);
         logger.trace("Executing command: %s".formatted(stringCommand));
         Runtime runtime = Runtime.getRuntime();

--- a/src/main/java/com/wireguard/external/shell/ShellRunner.java
+++ b/src/main/java/com/wireguard/external/shell/ShellRunner.java
@@ -28,7 +28,9 @@ public class ShellRunner {
     public String execute(String[] command, List<Integer> allowedExitCodes) {
         Process process = startProcess(command);
         int exitCode = waitForProcess(process);
+        System.out.println("redirecting stdout");
         String stdout = readInputStream(process.getInputStream());
+        System.out.println("redirecting stderr");
         String stderr = readInputStream(process.getErrorStream());
         if (!allowedExitCodes.contains(exitCode)) {
             throw new CommandExecutionException(String.join(" ", command), exitCode, stdout, stderr);

--- a/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.Scanner;
 import java.util.stream.Stream;
 
 @Profile("test")
@@ -21,7 +22,7 @@ public class FakeWgTool extends WgTool {
     @Override
     public WgShowDump showDump(String interfaceName) {
         File wgShowDumpFile = new File("src/main/resources/test-data/wg_show_dump.txt");
-        String dump = streamToStringConverter.convert(new FileInputStream(wgShowDumpFile));
+        Scanner dump = new Scanner(new FileInputStream(wgShowDumpFile));
         return WgShowDumpParser.fromDump(dump);
     }
 

--- a/src/main/java/com/wireguard/parser/WgShowDumpParser.java
+++ b/src/main/java/com/wireguard/parser/WgShowDumpParser.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
+import java.io.BufferedReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -22,19 +23,18 @@ public class WgShowDumpParser {
     private WgShowDumpParser() {
     }
 
-    public static WgShowDump fromDump(String dump) {
-        logger.trace("Parsing dump %s".formatted(dump));
-        Scanner scanner = new Scanner(dump);
-        if (!scanner.hasNextLine()) {
+    public static WgShowDump fromDump(Scanner dump) {
+        logger.trace("Parsing dump.. ");
+        if (!dump.hasNextLine()) {
             throw new IllegalArgumentException("Dump is empty");
         }
-        String dumpHeader = scanner.nextLine();
+        String dumpHeader = dump.nextLine();
         try {
             WgInterfaceDTO wgInterfaceDTO = parseInterface(dumpHeader);
-            List<WgPeer> peers = parsePeers(scanner);
+            List<WgPeer> peers = parsePeers(dump);
             return new WgShowDump(wgInterfaceDTO, peers);
         } catch (Exception e) {
-            logger.error("Error while parsing dump \n%s".formatted(dump));
+            logger.error("Error while parsing dump \n%s".formatted(dump.toString()));
             throw e;
         }
     }
@@ -56,5 +56,7 @@ public class WgShowDumpParser {
         Assert.notNull(wgShowInterfaceLine, "Wg interface dump is null");
         return WgInterfaceParser.parse(wgShowInterfaceLine, SPLITTER);
     }
+
+
 
 }

--- a/src/test/java/com/wireguard/parser/WgShowDumpParserTest.java
+++ b/src/test/java/com/wireguard/parser/WgShowDumpParserTest.java
@@ -13,10 +13,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Scanner;
 import java.util.Set;
 
 class WgShowDumpParserTest {
-    private String wgShowDump;
+    private Scanner wgShowDump;
 //public-key, preshared-key, endpoint, allowed-ips, latest-handshake, transfer-rx, transfer-tx, persistent-keepalive.
     private static final String FIRST_PEER_ALLOWED_IPS = "10.66.66.2/32,fd42:42:42::2/128";
     private static final String FIRST_PEER_ENDPOINT = "90.255.84.234:62517";
@@ -26,7 +27,7 @@ class WgShowDumpParserTest {
     void setUp() throws FileNotFoundException {
         File wgshowdumpFile = new File("src/test/resources/wg_show_dump.txt");
         StreamToStringConverter streamToStringConverter = new StreamToStringConverter();
-        wgShowDump = streamToStringConverter.convert(new FileInputStream(wgshowdumpFile));
+        wgShowDump = new Scanner(new FileInputStream(wgshowdumpFile));
     }
 
     @Test
@@ -61,14 +62,14 @@ class WgShowDumpParserTest {
     @Test
     void emptyDumpTest(){
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            WgShowDumpParser.fromDump("");
+            WgShowDumpParser.fromDump(new Scanner(""));
         });
     }
 
     @Test
     void invalidDumpTest(){
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            WgShowDumpParser.fromDump("invalid dump");
+            WgShowDumpParser.fromDump(new Scanner("invalid dump"));
         });
     }
 


### PR DESCRIPTION
Problem: WireRest breaks when Runtime.exec() inputStream reach the limit of buffer
Solution: Now program don't wait for process end. It's reading inputStream straightaway