### PR TITLE
No more manually entering the subnet, IP and port of Wireguard! Now it detects automatically

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
     }
     post {
         failure {
-            sh 'journalctl -u wirerest.service --no-pager -n 250'
+            sh 'sudo journalctl -u wirerest.service --no-pager -n 250'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,4 +39,8 @@ pipeline {
 
 
     }
+    post {
+    failure {
+        sh 'systemctl status ${SERVICE_NAME}'
+    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
     }
     post {
         failure {
-            sh 'systemctl status ${SERVICE_NAME}'
+            sh 'journalctl -u wirerest.service --no-pager -n 250'
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ Server run on port 8081
 java -jar wire-rest.jar 
     --server.port=8081 # WireRest port
     --wg.interface.name=wg0 # Wireguard interface name
-    --wg.interface.subnet=10.66.66.0/24 # Subnet with which wireguard works
-    --wg.interface.ip=10.66.66.1 # Ip of wireguard
-    --wg.interface.port=51820 # Port of wireguard
     --wg.interface.new_client_subnet_mask=32 # Mask for ip of new peers
 ```
 

--- a/src/main/java/com/wireguard/external/network/IpResolver.java
+++ b/src/main/java/com/wireguard/external/network/IpResolver.java
@@ -1,4 +1,4 @@
-package com.wireguard.external.wireguard;
+package com.wireguard.external.network;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,7 +17,7 @@ public class IpResolver {
 
 
 
-    private List<IpRange> availableRanges = new ArrayList<>();
+    private final List<IpRange> availableRanges = new ArrayList<>();
     private final IpRange totalAvailableRange;
     @Getter
     private final long totalIpsCount;
@@ -53,7 +53,7 @@ public class IpResolver {
     }
 
     public void takeIp(String ip){
-        takeSubnet(Subnet.fromString(ip+"/32"));
+        takeSubnet(Subnet.valueOf(ip+"/32"));
     }
 
     public void takeSubnet(Subnet subnet){

--- a/src/main/java/com/wireguard/external/network/NetworkInterfaceDTO.java
+++ b/src/main/java/com/wireguard/external/network/NetworkInterfaceDTO.java
@@ -1,0 +1,44 @@
+package com.wireguard.external.network;
+
+import lombok.Getter;
+
+import java.net.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class NetworkInterfaceDTO {
+    @Getter  private final String name;
+
+
+    private final Set<Subnet> ipv4Subnets = new HashSet<>();
+    private final Set<Inet4Address> ipv4Addresses = new HashSet<>();
+
+    public NetworkInterfaceDTO(String name){
+        this.name = name;
+    }
+
+    public Set<Subnet> getCidrV4Address() {
+        return Collections.unmodifiableSet(ipv4Subnets);
+    }
+
+    public Set<Inet4Address> getIpv4Addresses(){
+        return Collections.unmodifiableSet(ipv4Addresses);
+    }
+
+    public void addInterfaceAddress(InterfaceAddress interfaceAddress){
+        if (interfaceAddress.getAddress() instanceof Inet4Address)
+            ipv4Subnets.add(Subnet.valueOf((Inet4Address) interfaceAddress.getAddress(),
+                    interfaceAddress.getNetworkPrefixLength()));
+        else throw new IllegalArgumentException("Only IPv4 addresses are supported");
+    }
+
+    public void addInterfaceAddress(Subnet subnet){
+        ipv4Subnets.add(subnet);
+    }
+
+    public void addAddress(Inet4Address address){
+        ipv4Addresses.add(address);
+    }
+}

--- a/src/main/java/com/wireguard/external/network/NoFreeIpException.java
+++ b/src/main/java/com/wireguard/external/network/NoFreeIpException.java
@@ -1,4 +1,4 @@
-package com.wireguard.external.wireguard;
+package com.wireguard.external.network;
 
 public class NoFreeIpException extends RuntimeException{
     public NoFreeIpException(String message){

--- a/src/main/java/com/wireguard/external/network/Subnet.java
+++ b/src/main/java/com/wireguard/external/network/Subnet.java
@@ -1,9 +1,10 @@
-package com.wireguard.external.wireguard;
+package com.wireguard.external.network;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.springframework.util.Assert;
 
+import java.net.Inet4Address;
 import java.util.List;
 
 @EqualsAndHashCode
@@ -14,11 +15,15 @@ public class Subnet {
     private static final String IP_VALIDATE_REGEX = "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)(\\.(?!$)|$)){4}$";
 
 
-    public static Subnet fromString(String subnet){
+    public static Subnet valueOf(String subnet){
         Assert.isTrue(subnet.contains("/"), subnet+ " is not a valid subnet");
         String ip = subnet.split("/")[0];
         int mask = Integer.parseInt(subnet.split("/")[1]);
         return new Subnet(parseIp(ip), mask);
+    }
+
+    public static Subnet valueOf(Inet4Address inet4Address, int mask){
+        return new Subnet(inet4Address.getAddress(), mask);
     }
 
     public Subnet(byte[] ip, int mask){

--- a/src/main/java/com/wireguard/external/wireguard/Config.java
+++ b/src/main/java/com/wireguard/external/wireguard/Config.java
@@ -1,82 +1,87 @@
 package com.wireguard.external.wireguard;
 
+import com.wireguard.external.network.IpResolver;
+import com.wireguard.external.network.NetworkInterfaceDTO;
+import com.wireguard.external.network.Subnet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
-import java.io.IOException;
 import java.net.*;
-import java.util.Enumeration;
-import java.util.List;
+import java.util.function.Consumer;
 
 @Configuration
 public class Config {
 
     private static final Logger logger = LoggerFactory.getLogger(Config.class);
-    @Value("${wg.interface.subnet}")
-    private String interfaceSubnetString;
+    WgTool wgTool;
+
+    @Autowired
+    public Config(WgTool wgTool) {
+        this.wgTool = wgTool;
+    }
+
 
     @Bean
-    public IpResolver ipResolver(
-            WgTool wgTool,
-            WgInterface wgInterface
-    ) throws IOException {
+    public IpResolver ipResolver(NetworkInterfaceDTO wgInterface) {
         logger.info("Configuring IpResolver...");
-        Subnet interfaceSubnet = getInterfaceSubnet();
-        IpResolver ipResolver = new IpResolver(interfaceSubnet);
-        ipResolver.takeIp(interfaceSubnet.getFirstIpString());
-        ipResolver.takeIp(interfaceSubnet.getLastIpString());
-        ipResolver.takeIp(wgInterface.ip());
-
-        wgTool.showDump(wgInterface.name()).peers().forEach(
-                peer ->
-                        peer.getAllowedIps().getIPv4IPs().forEach(
-                                allowedIp ->
-                                    ipResolver.takeSubnet(Subnet.fromString(allowedIp))
-                        )
+        Subnet interfaceSubnet = wgInterface.getCidrV4Address().stream().findFirst().orElseThrow(
+                () -> new RuntimeException("Interface " + wgInterface.getName() + " has no IPv4 address")
         );
+        IpResolver ipResolver = new IpResolver(interfaceSubnet);
 
+        if (interfaceSubnet.getNumericMask()<=30) {
+            ipResolver.takeIp(interfaceSubnet.getFirstIpString());
+            ipResolver.takeIp(interfaceSubnet.getLastIpString());
+            wgInterface.getIpv4Addresses().forEach(iNet4Address -> ipResolver.takeIp(iNet4Address.getHostAddress()));
+        }
+        consumeBusyIps(ipResolver::takeIp, wgInterface.getName());
         return ipResolver;
     }
 
-    @Bean
-    public WgInterface wgInterface(
-            @Value("${wg.interface.name}") String interfaceName
-    ) throws SocketException {
-        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-        while(interfaces.hasMoreElements()) {
-            NetworkInterface networkInterface = interfaces.nextElement();
-            System.out.println(networkInterface.getName());
-            System.out.println(networkInterface.getDisplayName());
-            System.out.println(networkInterface.getIndex());
-            System.out.println(networkInterface.getMTU());
-            System.out.println(networkInterface.isLoopback());
-            System.out.println(networkInterface.isPointToPoint());
-            System.out.println(networkInterface.isUp());
-            System.out.println(networkInterface.isVirtual());
-            System.out.println(networkInterface.supportsMulticast());
-            System.out.println(networkInterface.getHardwareAddress());
-            System.out.println(networkInterface.getInterfaceAddresses());
-            System.out.println(networkInterface.getSubInterfaces());
-            System.out.println(networkInterface.getParent());
-            System.out.println(networkInterface.getNetworkInterfaces());
-            System.out.println(networkInterface.getSubInterfaces());
-            System.out.println(networkInterface.getInterfaceAddresses());
-            System.out.println("\n\n");
-            Enumeration<InetAddress> inetAddresses = networkInterface.getInetAddresses();
-            // ...
-        }
-        logger.info("Configuring WgInterface...");
-        return new WgInterface(interfaceName, "10.11.1.1", getInterfaceSubnet());
+
+
+    private void consumeBusyIps(Consumer<String> consumer, String interfaceName) {
+        wgTool.showDump(interfaceName).peers().forEach(
+                peer -> peer.getAllowedIps().getIPv4IPs().forEach(consumer)
+        );
     }
 
 
+    @Profile("prod")
+    @Bean
+    public NetworkInterfaceDTO wgInterface(
+            @Value("${wg.interface.name}") String interfaceName
+    ) throws SocketException {
+        NetworkInterface networkInterface = NetworkInterface.getByName(interfaceName);
+        if (networkInterface == null) {
+            logger.error("Network interface {} not found", interfaceName);
+            throw new RuntimeException("Network interface not found");
+        }
+        NetworkInterfaceDTO networkInterfaceDTO = new NetworkInterfaceDTO(interfaceName);
+        networkInterface.getInterfaceAddresses().forEach(networkInterfaceDTO::addInterfaceAddress);
+        networkInterface.getInetAddresses().asIterator().forEachRemaining(
+                inetAddress -> {
+                    if (inetAddress instanceof Inet4Address) networkInterfaceDTO.addAddress((Inet4Address) inetAddress);
+                });
+        return networkInterfaceDTO;
+    }
 
-
-
-    private Subnet getInterfaceSubnet(){
-        return Subnet.fromString(interfaceSubnetString);
+    @Profile("test")
+    @Bean
+    public NetworkInterfaceDTO wgInterfaceTest(
+            @Value("${wg.interface.name}") String interfaceName,
+            @Value("${wg.test.interface.cidr}") String cidr,
+            @Value("${wg.test.interface.interfaceIp}") String interfaceIp
+    ) throws UnknownHostException {
+        NetworkInterfaceDTO networkInterfaceDTO = new NetworkInterfaceDTO(interfaceName);
+        Subnet subnet = Subnet.valueOf(cidr);
+        networkInterfaceDTO.addInterfaceAddress(subnet);
+        networkInterfaceDTO.addAddress((Inet4Address) Inet4Address.getByName(interfaceIp));
+        return networkInterfaceDTO;
     }
 }

--- a/src/main/java/com/wireguard/external/wireguard/Config.java
+++ b/src/main/java/com/wireguard/external/wireguard/Config.java
@@ -7,6 +7,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.IOException;
+import java.net.*;
+import java.util.Enumeration;
+import java.util.List;
 
 @Configuration
 public class Config {
@@ -40,11 +43,33 @@ public class Config {
 
     @Bean
     public WgInterface wgInterface(
-            @Value("${wg.interface.name}") String interfaceName,
-            @Value("${wg.interface.ip}") String interfaceIp
-    ){
+            @Value("${wg.interface.name}") String interfaceName
+    ) throws SocketException {
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        while(interfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = interfaces.nextElement();
+            System.out.println(networkInterface.getName());
+            System.out.println(networkInterface.getDisplayName());
+            System.out.println(networkInterface.getIndex());
+            System.out.println(networkInterface.getMTU());
+            System.out.println(networkInterface.isLoopback());
+            System.out.println(networkInterface.isPointToPoint());
+            System.out.println(networkInterface.isUp());
+            System.out.println(networkInterface.isVirtual());
+            System.out.println(networkInterface.supportsMulticast());
+            System.out.println(networkInterface.getHardwareAddress());
+            System.out.println(networkInterface.getInterfaceAddresses());
+            System.out.println(networkInterface.getSubInterfaces());
+            System.out.println(networkInterface.getParent());
+            System.out.println(networkInterface.getNetworkInterfaces());
+            System.out.println(networkInterface.getSubInterfaces());
+            System.out.println(networkInterface.getInterfaceAddresses());
+            System.out.println("\n\n");
+            Enumeration<InetAddress> inetAddresses = networkInterface.getInetAddresses();
+            // ...
+        }
         logger.info("Configuring WgInterface...");
-        return new WgInterface(interfaceName, interfaceIp);
+        return new WgInterface(interfaceName, "10.11.1.1", getInterfaceSubnet());
     }
 
 

--- a/src/main/java/com/wireguard/external/wireguard/Config.java
+++ b/src/main/java/com/wireguard/external/wireguard/Config.java
@@ -63,7 +63,13 @@ public class Config {
             throw new RuntimeException("Network interface not found");
         }
         NetworkInterfaceDTO networkInterfaceDTO = new NetworkInterfaceDTO(interfaceName);
-        networkInterface.getInterfaceAddresses().forEach(networkInterfaceDTO::addInterfaceAddress);
+        networkInterface.getInterfaceAddresses().stream()
+                        .filter(interfaceAddress -> interfaceAddress.getAddress() instanceof Inet4Address)
+                        .findFirst().ifPresentOrElse( networkInterfaceDTO::addInterfaceAddress,
+                            () -> {
+                                logger.error("Network interface {} has no IPv4 address", interfaceName);
+                                throw new RuntimeException("Network interface %s has no IPv4 address".formatted(interfaceName));
+                            });
         networkInterface.getInetAddresses().asIterator().forEachRemaining(
                 inetAddress -> {
                     if (inetAddress instanceof Inet4Address) networkInterfaceDTO.addAddress((Inet4Address) inetAddress);

--- a/src/main/java/com/wireguard/external/wireguard/WgInterface.java
+++ b/src/main/java/com/wireguard/external/wireguard/WgInterface.java
@@ -1,5 +1,0 @@
-package com.wireguard.external.wireguard;
-
-
-public record WgInterface(String name, String ip, Subnet subnet){
-}

--- a/src/main/java/com/wireguard/external/wireguard/WgInterface.java
+++ b/src/main/java/com/wireguard/external/wireguard/WgInterface.java
@@ -1,5 +1,5 @@
 package com.wireguard.external.wireguard;
 
 
-public record WgInterface(String name, String ip) {
+public record WgInterface(String name, String ip, Subnet subnet){
 }

--- a/src/main/java/com/wireguard/external/wireguard/WgManager.java
+++ b/src/main/java/com/wireguard/external/wireguard/WgManager.java
@@ -1,5 +1,8 @@
 package com.wireguard.external.wireguard;
 
+import com.wireguard.external.network.IpResolver;
+import com.wireguard.external.network.NetworkInterfaceDTO;
+import com.wireguard.external.network.Subnet;
 import com.wireguard.external.shell.ShellRunner;
 import com.wireguard.external.wireguard.dto.CreatedPeer;
 import com.wireguard.external.wireguard.dto.WgInterfaceDTO;
@@ -11,7 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
+import java.net.NetworkInterface;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -21,14 +24,14 @@ import java.util.Set;
 public class WgManager {
 
     private static final Logger logger = LoggerFactory.getLogger(ShellRunner.class);
-    private final WgInterface wgInterface;
+    private final NetworkInterfaceDTO wgInterface;
     @Value("${wg.interface.new_client_subnet_mask}")
     private int defaultMaskForNewClients = 32;
     private final IpResolver wgIpResolver;
     private static WgTool wgTool;
 
     @Autowired
-    public WgManager(WgTool wgTool, IpResolver wgIpResolver, WgInterface wgInterface) {
+    public WgManager(WgTool wgTool, IpResolver wgIpResolver, NetworkInterfaceDTO wgInterface) {
         WgManager.wgTool = wgTool;
         this.wgIpResolver = wgIpResolver;
         this.wgInterface = wgInterface;
@@ -42,12 +45,7 @@ public class WgManager {
 
 
     private WgShowDump getDump() {
-        try{
-            return wgTool.showDump(wgInterface.name());
-        } catch (IOException e) {
-            logger.error("Error getting dump", e);
-            throw new ParsingException("Error while getting dump", e);
-        }
+        return wgTool.showDump(wgInterface.getName());
     }
 
     public Optional<WgPeerDTO> getPeerDTOByPublicKey(String publicKey) throws ParsingException {
@@ -81,11 +79,11 @@ public class WgManager {
                 privateKey,
                 Set.of(address.toString()),
                 0);
-        wgTool.addPeer(wgInterface.name(), createdPeer);
+        wgTool.addPeer(wgInterface.getName(), createdPeer);
         return createdPeer;
     }
 
     public void deletePeer(String publicKey)  {
-        wgTool.deletePeer(wgInterface.name(), publicKey);
+        wgTool.deletePeer(wgInterface.getName(), publicKey);
     }
 }

--- a/src/main/java/com/wireguard/external/wireguard/WgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/WgTool.java
@@ -53,7 +53,7 @@ public class WgTool {
 
 
 
-    public WgShowDump showDump(String interfaceName) throws IOException {
+    public WgShowDump showDump(String interfaceName) {
         Scanner scanner = runToScanner(WG_SHOW_DUMP_COMMAND.formatted(interfaceName), true);
         return WgShowDumpParser.fromDump(scanner);
     }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -6,21 +6,6 @@
       "description": "Wireguard interface name (interface should be already created)."
     },
     {
-      "name": "wg.interface.subnet",
-      "type": "java.lang.String",
-      "description": "Wireguard attached subnet (should be already created)."
-    },
-    {
-      "name": "wg.interface.ip",
-      "type": "java.net.InetAddress",
-      "description": "Wireguard interface IP address."
-    },
-    {
-      "name": "wg.interface.port",
-      "type": "java.lang.String",
-      "description": "Wireguard interface port."
-    },
-    {
       "name": "wg.interface.new_client_subnet_mask",
       "type": "java.lang.Integer",
       "description": "Mask for clients created with default params."

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,2 +1,3 @@
 wg.interface.subnet=10.0.0.1/24
 wg.interface.ip=10.0.0.1
+wg.interface.name=fokidoki-adblock

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,3 +1,5 @@
 wg.interface.subnet=10.0.0.1/24
 wg.interface.ip=10.0.0.1
-wg.interface.name=fokidoki-adblock
+wg.interface.name=eth4
+wg.test.interface.cidr=10.0.0.0/16
+wg.test.interface.interfaceIp=10.0.0.1

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-spring.profiles.active=test
+spring.profiles.active=prod
 wg.interface.name=wg0
-wg.interface.port=51820
+
 wg.interface.new_client_subnet_mask=32
 
 springdoc.swagger-ui.disable-swagger-default-url=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,5 @@
 spring.profiles.active=test
 wg.interface.name=wg0
-wg.interface.subnet=10.66.66.0/24
-wg.interface.ip=10.66.66.1
 wg.interface.port=51820
 wg.interface.new_client_subnet_mask=32
 

--- a/src/test/java/com/wireguard/api/peer/PeerControllerTest.java
+++ b/src/test/java/com/wireguard/api/peer/PeerControllerTest.java
@@ -1,6 +1,6 @@
 package com.wireguard.api.peer;
 
-import com.wireguard.external.wireguard.NoFreeIpException;
+import com.wireguard.external.network.NoFreeIpException;
 import com.wireguard.external.wireguard.WgManager;
 import com.wireguard.external.wireguard.WgPeer;
 import com.wireguard.external.wireguard.dto.CreatedPeer;

--- a/src/test/java/com/wireguard/external/wireguard/SubnetTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/SubnetTest.java
@@ -1,5 +1,6 @@
 package com.wireguard.external.wireguard;
 
+import com.wireguard.external.network.Subnet;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -10,19 +11,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class SubnetTest {
     @Test
     public void numericIpConvertTest2() {
-        Subnet subnet = Subnet.fromString("0.1.0.0/24");
+        Subnet subnet = Subnet.valueOf("0.1.0.0/24");
         assertEquals(65536L, subnet.getFirstIpNumeric(), ".getIpNumeric()");
     }
 
     @Test
     public void numericIpConvertTest3() {
-        Subnet subnet = Subnet.fromString("0.0.1.0/24");
+        Subnet subnet = Subnet.valueOf("0.0.1.0/24");
         assertEquals(256L, subnet.getFirstIpNumeric(), ".getIpNumeric()");
     }
 
     @Test
     public void testFromString() {
-        Subnet subnet = Subnet.fromString("192.168.0.3/24");
+        Subnet subnet = Subnet.valueOf("192.168.0.3/24");
         assertEquals("192.168.0.255", subnet.getLastIpString(), ".getLastIpString()");
         assertEquals("192.168.0.0", subnet.getFirstIpString(), ".getFirstIpString()");
         assertEquals(256, subnet.getIpCount(), ".getIpCount()");
@@ -33,7 +34,7 @@ class SubnetTest {
 
     @Test
     public void largeSubnetTest() {
-        Subnet subnet = Subnet.fromString("0.0.0.0/0");
+        Subnet subnet = Subnet.valueOf("0.0.0.0/0");
         assertEquals("0.0.0.0", subnet.getFirstIpString(), ".getFirstIpString()");
         assertEquals("255.255.255.255", subnet.getLastIpString(), ".getLastIpString()");
         assertEquals(4294967296L, subnet.getIpCount(), ".getIpCount()");
@@ -44,50 +45,50 @@ class SubnetTest {
 
     @Test
     public void testFromBadStringWrongIp() {
-        assertThrows(IllegalArgumentException.class, () -> Subnet.fromString("192.999.0.3/24"));
+        assertThrows(IllegalArgumentException.class, () -> Subnet.valueOf("192.999.0.3/24"));
     }
 
     @Test
     public void testFromBadString() {
-        assertThrows(IllegalArgumentException.class, () -> Subnet.fromString("hello world"));
+        assertThrows(IllegalArgumentException.class, () -> Subnet.valueOf("hello world"));
     }
 
     @Test
     public void testFromNullString() {
-        assertThrows(NullPointerException.class, () -> Subnet.fromString(null));
+        assertThrows(NullPointerException.class, () -> Subnet.valueOf(null));
     }
 
     @Test
     public void testFromNullStringWrongMaskLess0() {
-        assertThrows(IllegalArgumentException.class, () -> Subnet.fromString("192.168.0.1/-1"));
+        assertThrows(IllegalArgumentException.class, () -> Subnet.valueOf("192.168.0.1/-1"));
     }
 
     @Test
     public void testFromNullStringWrongMaskMore32() {
-        assertThrows(IllegalArgumentException.class, () -> Subnet.fromString("192.168.0.1/33"));
+        assertThrows(IllegalArgumentException.class, () -> Subnet.valueOf("192.168.0.1/33"));
     }
 
     @Test
     public void testGetLastIpNumeric() {
-        Subnet subnet = Subnet.fromString("0.0.0.0/17");
+        Subnet subnet = Subnet.valueOf("0.0.0.0/17");
         assertEquals(32767L, subnet.getLastIpNumeric(), ".getLastIpNumeric()");
     }
 
     @Test
     public void getIpTest() {
-        Subnet subnet = Subnet.fromString("192.168.0.2/17");
+        Subnet subnet = Subnet.valueOf("192.168.0.2/17");
         assertEquals(List.of(192,168,0,2), subnet.getIp(), ".getIp()");
     }
 
     @Test
     public void getFirstIpTest() {
-        Subnet subnet = Subnet.fromString("192.168.0.5/20");
+        Subnet subnet = Subnet.valueOf("192.168.0.5/20");
         assertEquals(List.of(192,168,0,0), subnet.getFirstIp(), ".getFirstIp()");
     }
 
     @Test
     public void getLastIpTest() {
-        Subnet subnet = Subnet.fromString("192.168.0.5/20");
+        Subnet subnet = Subnet.valueOf("192.168.0.5/20");
         assertEquals(List.of(192, 168, 15, 255), subnet.getLastIp(), ".getLastIp()");
 
     }

--- a/src/test/java/com/wireguard/external/wireguard/WgManagerTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/WgManagerTest.java
@@ -57,7 +57,7 @@ class WgManagerTest {
         wgManager = new WgManager(
                 wgTool,
                 ipResolver,
-                new WgInterface(wgInterfaceName, "10.0.0.0"));
+                new WgInterface(wgInterfaceName, "10.0.0.0", null));
     }
 
     @AfterAll

--- a/src/test/java/com/wireguard/external/wireguard/WgManagerTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/WgManagerTest.java
@@ -1,5 +1,8 @@
 package com.wireguard.external.wireguard;
 
+import com.wireguard.external.network.IpResolver;
+import com.wireguard.external.network.NetworkInterfaceDTO;
+import com.wireguard.external.network.Subnet;
 import com.wireguard.external.wireguard.dto.CreatedPeer;
 import com.wireguard.external.wireguard.dto.WgInterfaceDTO;
 import com.wireguard.external.wireguard.dto.WgPeerDTO;
@@ -51,13 +54,14 @@ class WgManagerTest {
         Mockito.when(wgTool.generatePresharedKey()).thenReturn("generatedPsk");
         Mockito.when(wgTool.generatePublicKey("generatedPrivateKey")).thenReturn("GeneratedPubKeyFromPrivateKey");
 
-        IpResolver ipResolver = new IpResolver(Subnet.fromString("10.0.0.0/16"));
-        ipResolver.takeSubnet(Subnet.fromString("10.0.0.0/31"));
+        NetworkInterfaceDTO wgInterface = new NetworkInterfaceDTO(wgInterfaceName);
+        IpResolver ipResolver = new IpResolver(Subnet.valueOf("10.0.0.0/16"));
+        ipResolver.takeSubnet(Subnet.valueOf("10.0.0.0/31"));
 
         wgManager = new WgManager(
                 wgTool,
                 ipResolver,
-                new WgInterface(wgInterfaceName, "10.0.0.0", null));
+                wgInterface);
     }
 
     @AfterAll


### PR DESCRIPTION

java -jar wire-rest.jar 
    --server.port=8081 # WireRest port
    --wg.interface.name=wg0 # Wireguard interface name
    ~~--wg.interface.subnet=10.66.66.0/24 # Subnet with which wireguard works~~
    ~~--wg.interface.ip=10.66.66.1 # Ip of wireguard~~
  ~~--wg.interface.port=51820 # Port of wireguard~~
    --wg.interface.new_client_subnet_mask=32 # Mask for ip of new peers

