### PR TITLE
Saving the config is not on every client (Rate limit). Improved performance on large configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+logs/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,12 @@ pipeline {
     environment {
         RUN_PROFILES="prod"
         RUN_PORT=8081
-        POM_VERSION="0.3"
+        POM_VERSION="0.3.1-MT"
         SERVICE_NAME="wirerest"
-        RUN_ARGS="--spring.profiles.active=${RUN_PROFILES} --server.port=${RUN_PORT} --debug"
+        RUN_ARGS="--spring.profiles.active=${RUN_PROFILES}
+        --server.port=${RUN_PORT}
+        --wg.interface.name=server
+        --debug"
     }
     stages {
         stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,10 @@ pipeline {
         RUN_PORT=8081
         POM_VERSION="0.3.1-MT"
         SERVICE_NAME="wirerest"
-        RUN_ARGS="--spring.profiles.active=${RUN_PROFILES}
-        --server.port=${RUN_PORT}
-        --wg.interface.name=server
-        --debug"
+        RUN_ARGS="--spring.profiles.active=${RUN_PROFILES}" +
+        "--server.port=${RUN_PORT}" +
+        "--wg.interface.name=server" +
+        "--debug"
     }
     stages {
         stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,8 @@ pipeline {
         RUN_ARGS="--spring.profiles.active=${RUN_PROFILES} " +
         "--server.port=${RUN_PORT} " +
         "--wg.interface.name=server " +
-        "--debug "
+        "--debug " +
+        "--logging.level.root=DEBUG "
     }
     stages {
         stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,10 @@ pipeline {
         RUN_PORT=8081
         POM_VERSION="0.3.1-MT"
         SERVICE_NAME="wirerest"
-        RUN_ARGS="--spring.profiles.active=${RUN_PROFILES}" +
-        "--server.port=${RUN_PORT}" +
-        "--wg.interface.name=server" +
-        "--debug"
+        RUN_ARGS="--spring.profiles.active=${RUN_PROFILES} " +
+        "--server.port=${RUN_PORT} " +
+        "--wg.interface.name=server " +
+        "--debug "
     }
     stages {
         stage('Build') {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Java 20 required
 #### Default configuration:
 
 ```shell
-java -jar wirerest-0.2.jar
+java -jar wirerest-0.3.jar
 ```
 Server run on port 8081
 
@@ -51,7 +51,7 @@ mvn clean package
 ___
 - ~~Migration to Spring WebFlux~~
 - Metrics for Prometheus
-- Add peer (Custom configuration)
+- ~~Add peer (Custom configuration)~~
 - ~~Delete peer~~
 - Update peer
 - Oauth2 authorization

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>wireguard</groupId>
     <artifactId>wirerest</artifactId>
-    <version>0.3</version>
+    <version>0.3.1-MT</version>
     <name>WireRest</name>
     <description>WireRest - REST api for Wireguard</description>
     <properties>

--- a/src/main/java/com/wireguard/external/wireguard/WgManager.java
+++ b/src/main/java/com/wireguard/external/wireguard/WgManager.java
@@ -37,13 +37,13 @@ public class WgManager {
     @Value("${wg.interface.default.persistent_keepalive}")
     private final int DEFAULT_PERSISTENT_KEEPALIVE = 0;
     private final IpResolver wgIpResolver;
-    private static WgTool wgTool;
+    private final WgTool wgTool;
     WgPeerContainerToWgPeerDTOSet containerToPeer = new WgPeerContainerToWgPeerDTOSet();
     WgPeerIterableToWgPeerDTOList iterableToPeer = new WgPeerIterableToWgPeerDTOList();
 
     @Autowired
     public WgManager(WgTool wgTool, IpResolver wgIpResolver, NetworkInterfaceDTO wgInterface) {
-        WgManager.wgTool = wgTool;
+        this.wgTool = wgTool;
         this.wgIpResolver = wgIpResolver;
         this.wgInterface = wgInterface;
     }

--- a/src/main/java/com/wireguard/external/wireguard/WgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/WgTool.java
@@ -165,7 +165,9 @@ public class WgTool {
 
     }
     private void saveConfig(String interfaceName) {
-        configSaveTasks.add(new Task(() -> run(WG_SAVE_COMMAND.formatted(interfaceName), true)));
+        if (configSaveTasks.isEmpty()) {
+            configSaveTasks.add(new Task(() -> run(WG_SAVE_COMMAND.formatted(interfaceName), true)));
+        }
     }
 
 

--- a/src/main/java/com/wireguard/external/wireguard/WgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/WgTool.java
@@ -37,7 +37,7 @@ public class WgTool {
     static String presharedKeyPath = "/tmp/presharedKey";
     protected final ShellRunner shell = new ShellRunner();
 
-    private Queue<Task> configSaveTasks = new LinkedBlockingQueue<>(1);
+    private final Queue<Task> configSaveTasks = new LinkedBlockingQueue<>(1);
     private final RateLimitedExecutorService configSaveExecutor;
 
     @Autowired

--- a/src/main/java/com/wireguard/external/wireguard/WgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/WgTool.java
@@ -2,13 +2,20 @@ package com.wireguard.external.wireguard;
 
 import com.wireguard.external.shell.ShellRunner;
 import com.wireguard.external.wireguard.dto.CreatedPeer;
+import com.wireguard.external.wireguard.tools.RateLimitedExecutorService;
 import com.wireguard.parser.WgShowDumpParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.config.Task;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.List;
+import java.util.Queue;
+import java.util.Scanner;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
 
 @Profile("prod")
@@ -29,6 +36,14 @@ public class WgTool {
 
     static String presharedKeyPath = "/tmp/presharedKey";
     protected final ShellRunner shell = new ShellRunner();
+
+    private Queue<Task> configSaveTasks = new LinkedBlockingQueue<>(1);
+    private final RateLimitedExecutorService configSaveExecutor;
+
+    @Autowired
+    public WgTool(@Value("${wg.config.save.min-interval}") int configSaveMinInterval) {
+        this.configSaveExecutor = new RateLimitedExecutorService(configSaveTasks, configSaveMinInterval);
+    }
 
     private String run(String commandStr, Boolean privileged) {
         String[] command = getCommand(commandStr, privileged);
@@ -150,8 +165,10 @@ public class WgTool {
 
     }
     private void saveConfig(String interfaceName) {
-        run(WG_SAVE_COMMAND.formatted(interfaceName), true);
+        configSaveTasks.add(new Task(() -> run(WG_SAVE_COMMAND.formatted(interfaceName), true)));
     }
+
+
 
     public void deletePeer(String interfaceName, String publicKey) {
         run(WG_DEL_PEER_COMMAND.formatted(interfaceName, publicKey), true);

--- a/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
@@ -21,7 +21,7 @@ public class FakeWgTool extends WgTool {
     private int keyCounter;
 
     public FakeWgTool() {
-        super(0);
+        super(1);
         wgInterfaceDTO = new WgInterfaceDTO("privkey", "pubkey", 16666, 0);
         wgPeerContainer.addAll(List.of(
                 WgPeer.publicKey("pubkey1").build(),

--- a/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
@@ -21,6 +21,7 @@ public class FakeWgTool extends WgTool {
     private int keyCounter;
 
     public FakeWgTool() {
+        super(0);
         wgInterfaceDTO = new WgInterfaceDTO("privkey", "pubkey", 16666, 0);
         wgPeerContainer.addAll(List.of(
                 WgPeer.publicKey("pubkey1").build(),

--- a/src/main/java/com/wireguard/external/wireguard/tools/RateLimitedExecutorService.java
+++ b/src/main/java/com/wireguard/external/wireguard/tools/RateLimitedExecutorService.java
@@ -1,0 +1,37 @@
+package com.wireguard.external.wireguard.tools;
+
+import org.springframework.scheduling.config.Task;
+
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+
+public class RateLimitedExecutorService {
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
+    private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    private final int rateMs;
+    private final Queue<Task> tasks;
+    public RateLimitedExecutorService(Queue<Task> tasks, int rateMs){
+        this.rateMs = rateMs;
+        this.tasks = tasks;
+        start();
+    }
+
+    public void stop(){
+        scheduledExecutorService.shutdown();
+        executorService.shutdown();
+    }
+
+    public void start(){
+        scheduledExecutorService.scheduleAtFixedRate(() -> {
+            final Task task = tasks.poll();
+            if (task == null) return;
+            executorService.submit(task.getRunnable());
+        }, 0, rateMs, TimeUnit.MILLISECONDS);
+    }
+}
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,5 +3,6 @@ wg.interface.name=wg0
 
 wg.interface.default.mask=32
 wg.interface.default.persistent_keepalive=0
+wg.config.save.min-interval=2000
 springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.path=/swagger-ui

--- a/src/test/java/com/wireguard/external/wireguard/WgToolIntegrationTests.java
+++ b/src/test/java/com/wireguard/external/wireguard/WgToolIntegrationTests.java
@@ -19,7 +19,7 @@ class WgToolIntegrationTests {
     private final static File wgConfigFileSource = new File("src/test/resources/%s.conf".formatted(interfaceName));
     private static File wgConfigFile;
     private final static String interfacePublicKey = "sBdtuH6Q84CmecM+A832NOyAb9Oz0W7rJdPCR/JS63I=";
-    private final static WgTool wgTool = new WgTool();
+    private final static WgTool wgTool = new WgTool(0);
 
     @BeforeAll
     static void setUpEnvironment() throws IOException {

--- a/src/test/java/com/wireguard/external/wireguard/WgToolIntegrationTests.java
+++ b/src/test/java/com/wireguard/external/wireguard/WgToolIntegrationTests.java
@@ -19,7 +19,7 @@ class WgToolIntegrationTests {
     private final static File wgConfigFileSource = new File("src/test/resources/%s.conf".formatted(interfaceName));
     private static File wgConfigFile;
     private final static String interfacePublicKey = "sBdtuH6Q84CmecM+A832NOyAb9Oz0W7rJdPCR/JS63I=";
-    private final static WgTool wgTool = new WgTool(0);
+    private final static WgTool wgTool = new WgTool(1);
 
     @BeforeAll
     static void setUpEnvironment() throws IOException {


### PR DESCRIPTION

Now the config is not saved after each created peer. Saving occurs no more frequently than wg.config.save.min-interval ms. (2000 by default)
look at the diagram. Vertical axis - time to generate a new client (Fully automatic generation including PSK), Horizontal 
 axis - number of already added clients

![draw](https://github.com/FokiDoki/WireRest/assets/23121394/e9740f5d-bf07-4f3d-a8f2-09c720d3c75e)

The new version is almost independent of the number of existing clients, and generates clients in a stable time
