### PR TITLE
Caching added, performance improved

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     environment {
         RUN_PROFILES="prod"
         RUN_PORT=8081
-        POM_VERSION="0.3.2-LOG"
+        POM_VERSION="0.3.5-CAC"
         SERVICE_NAME="wirerest"
         RUN_ARGS="--spring.profiles.active=${RUN_PROFILES} " +
         "--server.port=${RUN_PORT} " +

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>wireguard</groupId>
     <artifactId>wirerest</artifactId>
-    <version>0.3.2-LOG</version>
+    <version>0.3.5-CAC</version>
     <name>WireRest</name>
     <description>WireRest - REST api for Wireguard</description>
     <properties>
@@ -30,7 +30,11 @@
             <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
             <version>2.0.4</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.5</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -62,12 +62,12 @@ public class PeerController {
     @GetMapping("/peers")
     @Parameter(name = "page", description = "Page number")
     @Parameter(name = "limit", description = "Page size (In case of 0, all peers will be returned)")
-    @Parameter(name = "sort", description = "Sort key and direction separated by a dot. The keys are the same as in the answer" +
-            "Direction is optional and may have value DESC (High to low) and ASC (Low to high). Default is allowedSubnets.DESC", example = "transferTx.desc")
+    @Parameter(name = "sort", description = "Sort key and direction separated by a dot. The keys are the same as in the answer. " +
+            "Direction is optional and may have value DESC (High to low) and ASC (Low to high). Using with a large number of peers (3000 or more) affects performance. ", example = "allowedSubnets.desc")
     public PageDTO<WgPeerDTO> getPeers(
             @RequestParam(value = "page", required = false, defaultValue = "0") int page,
             @RequestParam(value = "limit", required = false, defaultValue = "1000") int limit,
-            @RequestParam(value = "sort", required = false, defaultValue = "allowedSubnets.desc") String sortKey
+            @RequestParam(value = "sort", required = false) String sortKey
     ) throws ParsingException {
         Page<WgPeer> peers;
         if (limit == 0){
@@ -90,6 +90,9 @@ public class PeerController {
 
 
     private Sort getSort(String sortKey){
+        if (sortKey == null){
+            return Sort.unsorted();
+        }
         String[] keys = sortKey.split("\\.");
         if (keys.length == 1){
             return Sort.by(sortKey).descending();

--- a/src/main/java/com/wireguard/external/network/ISubnetSolver.java
+++ b/src/main/java/com/wireguard/external/network/ISubnetSolver.java
@@ -14,6 +14,8 @@ public interface ISubnetSolver {
 
     void release(Subnet subnet);
 
+    boolean isUsed(Subnet subnet);
+
     long getAvailableIpsCount();
 
     long getTotalIpsCount();

--- a/src/main/java/com/wireguard/external/network/QueuedSubnetSolver.java
+++ b/src/main/java/com/wireguard/external/network/QueuedSubnetSolver.java
@@ -45,6 +45,14 @@ public class QueuedSubnetSolver implements ISubnetSolver{
     }
 
     @SneakyThrows
+    @Override
+    public boolean isUsed(Subnet subnet) {
+        Future<Boolean> isUsedFuture = executor.submit(() -> subnetSolver.isUsed(subnet));
+        await(isUsedFuture);
+        return isUsedFuture.get();
+    }
+
+    @SneakyThrows
     private void await(Future<?> future){
         try {
             future.get();

--- a/src/main/java/com/wireguard/external/wireguard/EmptyPeerCreationRequest.java
+++ b/src/main/java/com/wireguard/external/wireguard/EmptyPeerCreationRequest.java
@@ -8,6 +8,6 @@ import java.util.Set;
 @EqualsAndHashCode(callSuper = true)
 public class EmptyPeerCreationRequest extends PeerCreationRequest{
     public EmptyPeerCreationRequest() {
-        super(null, null, null, null, null);
+        super(null, null, null, Set.of(), null, 0);
     }
 }

--- a/src/main/java/com/wireguard/external/wireguard/PeerCreationRequest.java
+++ b/src/main/java/com/wireguard/external/wireguard/PeerCreationRequest.java
@@ -17,4 +17,5 @@ public class PeerCreationRequest {
     private final String privateKey;
     private final Set<Subnet> allowedIps;
     private final Integer persistentKeepalive;
+    private final int countOfIpsToGenerate;
 }

--- a/src/main/java/com/wireguard/external/wireguard/config/Config.java
+++ b/src/main/java/com/wireguard/external/wireguard/config/Config.java
@@ -1,6 +1,7 @@
-package com.wireguard.external.wireguard;
+package com.wireguard.external.wireguard.config;
 
 import com.wireguard.external.network.*;
+import com.wireguard.external.wireguard.WgTool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/wireguard/external/wireguard/iface/CachedWgInterfaceService.java
+++ b/src/main/java/com/wireguard/external/wireguard/iface/CachedWgInterfaceService.java
@@ -1,0 +1,31 @@
+package com.wireguard.external.wireguard.iface;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.wireguard.external.network.NetworkInterfaceDTO;
+import com.wireguard.external.wireguard.WgTool;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@ConditionalOnProperty(value = "wg.cache.enabled", havingValue = "true")
+@Component
+public class CachedWgInterfaceService extends WgInterfaceService {
+
+    private final int REFRESH_INTERVAL_SECONDS = 300;
+
+    LoadingCache<String, WgInterface> wgInterfaceCache;
+    public CachedWgInterfaceService(NetworkInterfaceDTO wgInterface, WgTool wgTool) {
+        super(wgInterface, wgTool);
+        wgInterfaceCache = Caffeine.newBuilder()
+                .refreshAfterWrite(REFRESH_INTERVAL_SECONDS, TimeUnit.SECONDS)
+                .build(key -> super.getInterface());
+    }
+
+    @Override
+    public WgInterface getInterface() {
+        return wgInterfaceCache.get("");
+    }
+}

--- a/src/main/java/com/wireguard/external/wireguard/iface/WgInterfaceService.java
+++ b/src/main/java/com/wireguard/external/wireguard/iface/WgInterfaceService.java
@@ -2,9 +2,11 @@ package com.wireguard.external.wireguard.iface;
 
 import com.wireguard.external.network.NetworkInterfaceDTO;
 import com.wireguard.external.wireguard.WgTool;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(value = "wg.cache.enabled", havingValue = "false")
 public class WgInterfaceService {
 
     private final NetworkInterfaceDTO wgInterface;

--- a/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
@@ -1,2 +1,72 @@
-package com.wireguard.external.wireguard.peer;public class CachedWgPeerRepository {
+package com.wireguard.external.wireguard.peer;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.wireguard.external.network.NetworkInterfaceDTO;
+import com.wireguard.external.wireguard.RepositoryPageable;
+import com.wireguard.external.wireguard.Specification;
+import com.wireguard.external.wireguard.WgTool;
+import com.wireguard.external.wireguard.peer.spec.FindByPublicKey;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@ConditionalOnProperty(value = "api.cache.enabled", havingValue = "true")
+public class CachedWgPeerRepository extends WgPeerRepository implements RepositoryPageable<WgPeer> {
+
+    private final LoadingCache<String, WgPeer> wgPeerCache;
+    private final ScheduledExecutorService cacheUpdateScheduler = Executors.newSingleThreadScheduledExecutor();
+    private final static int UPDATE_INTERVAL_SECONDS = 10;
+
+
+    @Autowired
+    public CachedWgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface) {
+        super(wgTool, wgInterface);
+        wgPeerCache = Caffeine.newBuilder()
+                .refreshAfterWrite(UPDATE_INTERVAL_SECONDS, TimeUnit.SECONDS)
+                .build(key -> super.getBySpecification(new FindByPublicKey(key)).stream().findFirst().orElse(null));
+        cacheUpdateScheduler.scheduleAtFixedRate(this::updateCache, 0, UPDATE_INTERVAL_SECONDS, TimeUnit.SECONDS);
+
+    }
+
+    @Override
+    public void add(WgPeer wgPeer) {
+        wgPeerCache.put(wgPeer.getPublicKey(), wgPeer);
+        super.add(wgPeer);
+    }
+
+    @Override
+    public void remove(WgPeer wgPeer) {
+        wgPeerCache.invalidate(wgPeer.getPublicKey());
+        super.remove(wgPeer);
+    }
+
+    @Override
+    public void update(WgPeer oldT, WgPeer newT) {
+        wgPeerCache.put(newT.getPublicKey(), newT);
+        super.update(oldT, newT);
+    }
+
+    private void updateCache() {
+        wgPeerCache.invalidateAll();
+        for (WgPeer wgPeer : super.getAll()) {
+            wgPeerCache.put(wgPeer.getPublicKey(), wgPeer);
+        }
+    }
+
+    @Override
+    public List<WgPeer> getAll() {
+        return wgPeerCache.asMap().values().stream().toList();
+    }
+
 }

--- a/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
@@ -1,0 +1,2 @@
+package com.wireguard.external.wireguard.peer;public class CachedWgPeerRepository {
+}

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerCreator.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerCreator.java
@@ -40,10 +40,10 @@ public class WgPeerCreator {
         String presharedKey = peerCreationRequest.getPresharedKey() == null ? wgTool.generatePresharedKey() : peerCreationRequest.getPresharedKey();
         int persistentKeepalive = peerCreationRequest.getPersistentKeepalive() == null ? DEFAULT_PERSISTENT_KEEPALIVE : peerCreationRequest.getPersistentKeepalive();
         Set<Subnet> allowedIps = peerCreationRequest.getAllowedIps();
-        if (allowedIps == null) {
-            allowedIps = Set.of(wgSubnetSolver.obtainFree(DEFAULT_MASK_FOR_NEW_CLIENTS));
-        }
         obtainSubnets(allowedIps);
+        for (int i = 0; i < peerCreationRequest.getCountOfIpsToGenerate(); i++) {
+            allowedIps.add(wgSubnetSolver.obtainFree(DEFAULT_MASK_FOR_NEW_CLIENTS));
+        }
         logger.info("Created peer, public key: %s".formatted(publicKey.substring(0, Math.min(6, publicKey.length()))));
         return new CreatedPeer(publicKey, presharedKey, privateKey, allowedIps, persistentKeepalive);
 

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerCreator.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerCreator.java
@@ -18,7 +18,7 @@ import java.util.Set;
 @Component
 public class WgPeerCreator {
 
-    private static final Logger logger = LoggerFactory.getLogger(ShellRunner.class);
+    private static final Logger logger = LoggerFactory.getLogger(WgPeerCreator.class);
     @Value("${wg.interface.default.mask}")
     private final int DEFAULT_MASK_FOR_NEW_CLIENTS = 32;
     @Value("${wg.interface.default.persistent_keepalive}")

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
-@ConditionalOnProperty(value = "api.cache.enabled", havingValue = "false")
+@ConditionalOnProperty(value = "wg.cache.enabled", havingValue = "false")
 public class WgPeerRepository implements RepositoryPageable<WgPeer> {
 
     private final WgTool wgTool;

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
@@ -7,6 +7,7 @@ import com.wireguard.external.wireguard.RepositoryPageable;
 import com.wireguard.external.wireguard.Specification;
 import com.wireguard.external.wireguard.WgTool;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
+@ConditionalOnProperty(value = "api.cache.enabled", havingValue = "false")
 public class WgPeerRepository implements RepositoryPageable<WgPeer> {
 
     private final WgTool wgTool;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,5 @@ logging.api.max-elements=1000
 springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.path=/swagger-ui
 logging.file.path=logs
-api.cache.enabled=true
+wg.cache.enabled=true
+wg.cache.update-interval=60

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,4 @@ logging.api.max-elements=1000
 springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.path=/swagger-ui
 logging.file.path=logs
+api.cache.enabled=true

--- a/src/test/java/com/wireguard/api/peer/PeerControllerTest.java
+++ b/src/test/java/com/wireguard/api/peer/PeerControllerTest.java
@@ -187,7 +187,7 @@ class PeerControllerTest {
                 newPeer.getPresharedKey(),
                 newPeer.getPrivateKey(),
                 newPeer.getAllowedSubnets(),
-                25))).thenReturn(newPeer);
+                25, 0))).thenReturn(newPeer);
         webClient.post().uri(uriBuilder -> uriBuilder
                         .path("/peer/create")
                         .queryParam("publicKey", newPeer.getPublicKey())

--- a/src/test/java/com/wireguard/external/wireguard/WgPeerServiceTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/WgPeerServiceTest.java
@@ -91,14 +91,16 @@ class WgPeerServiceTest {
     @Test
     public void testCreatePeerGenerateNulls() {
         CreatedPeer shouldBeReturned = new CreatedPeer("publicKey", "Psk", "Ppk", Set.of(Subnet.valueOf("10.66.66.1/32")), 0);
-        Mockito.when(wgPeerCreator.createPeerGenerateNulls(new PeerCreationRequest("publicKey", "Psk", "Ppk", null, 0)))
+        Mockito.when(wgPeerCreator.createPeerGenerateNulls(
+                new PeerCreationRequest("publicKey", "Psk", "Ppk",
+                        null, 0, 1)))
                 .thenReturn(shouldBeReturned);
-        CreatedPeer createdPeer = wgPeerService.createPeerGenerateNulls(new PeerCreationRequest("publicKey", "Psk", "Ppk", null, 0));
+        CreatedPeer createdPeer = wgPeerService.createPeerGenerateNulls(new PeerCreationRequest("publicKey", "Psk", "Ppk", null, 0, 1));
         Assertions.assertNotNull(createdPeer);
         Assertions.assertEquals(shouldBeReturned, createdPeer);
         Mockito.verify(wgPeerCreator, Mockito.times(1)).createPeerGenerateNulls(
-                new PeerCreationRequest( shouldBeReturned.getPublicKey(), shouldBeReturned.getPresharedKey(), shouldBeReturned.getPrivateKey(),
-                null, shouldBeReturned.getPersistentKeepalive()));
+                new PeerCreationRequest(shouldBeReturned.getPublicKey(), shouldBeReturned.getPresharedKey(), shouldBeReturned.getPrivateKey(),
+                null, shouldBeReturned.getPersistentKeepalive(), 1));
         Mockito.verify(wgPeerRepository, Mockito.times(1)).add(Mockito.any(WgPeer.class));
     }
 

--- a/src/test/java/com/wireguard/external/wireguard/peer/WgPeerCreatorTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/peer/WgPeerCreatorTest.java
@@ -35,7 +35,7 @@ class WgPeerCreatorTest {
          CreatedPeer peer = wgPeerCreator.createPeerGenerateNulls(new EmptyPeerCreationRequest());
             assertEquals(wgPeerCreator.DEFAULT_PERSISTENT_KEEPALIVE, peer.getPersistentKeepalive());
             Mockito.verify(wgTool, Mockito.times(1)).generatePublicKey(Mockito.any());
-            Mockito.verify(subnetSolver, Mockito.times(1)).obtainFree(Mockito.anyInt());
+            Mockito.verify(subnetSolver, Mockito.times(0)).obtainFree(Mockito.anyInt());
             Mockito.verify(wgTool, Mockito.times(1)).generatePrivateKey();
             Mockito.verify(wgTool, Mockito.times(1)).generatePresharedKey();
     }
@@ -43,7 +43,7 @@ class WgPeerCreatorTest {
     @Test
     public void testCreatePeerWithData(){
         CreatedPeer peer = wgPeerCreator.createPeerGenerateNulls(new PeerCreationRequest("publicKey","presharedKey",
-                "privateKey", Set.of(Subnet.valueOf("0.0.0.1/32")),1));
+                "privateKey", Set.of(Subnet.valueOf("0.0.0.1/32")),1, 0));
         assertEquals(1, peer.getPersistentKeepalive());
         assertEquals("publicKey", peer.getPublicKey());
         assertEquals("presharedKey", peer.getPresharedKey());
@@ -62,7 +62,7 @@ class WgPeerCreatorTest {
         Set<Subnet> ips = Set.of(Subnet.valueOf("10.0.0.1/32"), Subnet.valueOf("10.0.0.2/32"));
         Assertions.assertThrows(RuntimeException.class, () -> {
             wgPeerCreator.createPeerGenerateNulls(new PeerCreationRequest(null,null,
-                    null,ips,null));
+                    null,ips,null, 0));
         });
     }
 


### PR DESCRIPTION
## Caching

Now /peers and /interface are cached. This means that WireRest will not ask wireguard for a dump for every request. Therefore, **if you add a peer not through WireRest**, it will **not appear** in the api **immediately**, but after some time.
Caching significantly improves performance on large configs (1000+ peers)

## Params 
Caching can be disabled with --wg.cache.enabled=false
Synchronization period can be set using the --wg.cache.update-interval=<seconds>  parameter. 
Interface synchronization time is static and is 300s

## Restrictions and Responsibilities

I **strongly do not recommend** creating peers bypassing WireRest when caching is enabled. WireRest will not know which ip address you took when you added a bypass peer, and a conflict may occur accordingly. He learns about the ip address only after he synchronizes, then everything will go fine. If you still add peers manually - assign them an ip address that is far from the last busy address, then WireRest will have time to synchronize.

## Other 
Sorting is disabled by default as it takes a lot of time on large configs