### PR TITLE
Fixed pages displaying

### DIFF
--- a/src/main/java/com/wireguard/api/dto/PageDTO.java
+++ b/src/main/java/com/wireguard/api/dto/PageDTO.java
@@ -9,13 +9,11 @@ import java.util.List;
 public class PageDTO<T> {
     private final int totalPages;
     private final int currentPage;
-    private final int pageSize;
     private final List<T> content;
 
-    public PageDTO(int totalPages, int currentPage, int pageSize, List<T> content) {
+    public PageDTO(int totalPages, int currentPage, List<T> content) {
         this.totalPages = totalPages;
         this.currentPage = currentPage;
-        this.pageSize = pageSize;
         this.content = content;
     }
 
@@ -23,7 +21,6 @@ public class PageDTO<T> {
         return new PageDTO<>(
                 page.getTotalPages(),
                 page.getNumber(),
-                page.getSize(),
                 page.getContent()
         );
     }

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -85,7 +85,7 @@ public class PeerController {
 
     private PageDTO<WgPeerDTO> pagePeerToPageDTOPeerDTO(Page<WgPeer> peers){
         List<WgPeerDTO> peerDTOs = peers.getContent().stream().map(WgPeerDTO::from).collect(Collectors.toList());
-        return new PageDTO<>(peers.getTotalPages(), peers.getNumber(), peers.getSize(), peerDTOs);
+        return new PageDTO<>(peers.getTotalPages()-1, peers.getNumber(), peerDTOs);
     }
 
 

--- a/src/main/java/com/wireguard/external/wireguard/PageOutOfRangeException.java
+++ b/src/main/java/com/wireguard/external/wireguard/PageOutOfRangeException.java
@@ -1,0 +1,7 @@
+package com.wireguard.external.wireguard;
+
+public class PageOutOfRangeException extends IllegalArgumentException {
+    public PageOutOfRangeException(int requestedPage, int totalPages) {
+        super("Requested %d page, but total pages is %d".formatted(requestedPage, totalPages));
+    }
+}

--- a/src/main/java/com/wireguard/external/wireguard/Paging.java
+++ b/src/main/java/com/wireguard/external/wireguard/Paging.java
@@ -69,6 +69,9 @@ public class Paging<T> {
         ArrayList<T> sorted = sort(pageable.getSort(), new ArrayList<T>(list));
         PagedListHolder<T> page = new PagedListHolder<>(sorted);
         page.setPageSize(pageable.getPageSize());
+        if (pageable.getPageNumber() >= page.getPageCount()) {
+            throw new PageOutOfRangeException(pageable.getPageNumber(), page.getPageCount()-1);
+        }
         page.setPage(pageable.getPageNumber());
         return new PageImpl<T>(new ArrayList<>(page.getPageList()), pageable, list.size());
     }


### PR DESCRIPTION
Prior to this, the pages were displayed incorrectly. Entering a non-existent page in the page parameter when requesting /peers returned the last available page and incorrectly displayed the number. Now if you enter an incorrect page, http code 400 will be returned. Now pages works  normally.