### PR TITLE
IPv6 Support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
 
         stage('Check'){
             steps {
-                sleep 15
+                sleep 20
                 sh 'curl -s http://127.0.0.1:${RUN_PORT}/interface  > /dev/null'
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
             <version>2.0.4</version>
         </dependency>
         <dependency>
+            <groupId>com.googlecode.java-ipv6</groupId>
+            <artifactId>java-ipv6</artifactId>
+            <version>0.17</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>3.1.5</version>

--- a/src/main/java/com/wireguard/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/wireguard/api/GlobalExceptionHandler.java
@@ -58,7 +58,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<AppError> commandExecutionException(CommandExecutionException e) {
         logger.error(e.getMessage(), e);
         return new ResponseEntity<>(
-                new AppError(HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                        "Wireguard error: %s".formatted(e.getStderr().strip())), HttpStatus.INTERNAL_SERVER_ERROR);
+                new AppError(HttpStatus.BAD_REQUEST.value(),
+                        "Wireguard error: %s".formatted(e.getStderr().strip())), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/wireguard/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/wireguard/api/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.wireguard.api;
 
 
 import com.wireguard.external.network.AlreadyUsedException;
+import com.wireguard.external.shell.CommandExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -51,5 +52,13 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(
                 new AppError(HttpStatus.BAD_REQUEST.value(),
                         e.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<AppError> commandExecutionException(CommandExecutionException e) {
+        logger.error(e.getMessage(), e);
+        return new ResponseEntity<>(
+                new AppError(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        "Wireguard error: %s".formatted(e.getStderr().strip())), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/wireguard/api/dto/PageDTO.java
+++ b/src/main/java/com/wireguard/api/dto/PageDTO.java
@@ -9,11 +9,13 @@ import java.util.List;
 public class PageDTO<T> {
     private final int totalPages;
     private final int currentPage;
+    private final int pageSize;
     private final List<T> content;
 
-    public PageDTO(int totalPages, int currentPage, List<T> content) {
+    public PageDTO(int totalPages, int currentPage, int pageSize, List<T> content) {
         this.totalPages = totalPages;
         this.currentPage = currentPage;
+        this.pageSize = pageSize;
         this.content = content;
     }
 
@@ -21,6 +23,7 @@ public class PageDTO<T> {
         return new PageDTO<>(
                 page.getTotalPages(),
                 page.getNumber(),
+                page.getSize(),
                 page.getContent()
         );
     }

--- a/src/main/java/com/wireguard/api/inteface/InterfaceController.java
+++ b/src/main/java/com/wireguard/api/inteface/InterfaceController.java
@@ -2,7 +2,6 @@ package com.wireguard.api.inteface;
 
 import com.wireguard.api.AppError;
 import com.wireguard.external.wireguard.ParsingException;
-import com.wireguard.external.wireguard.iface.WgInterface;
 import com.wireguard.external.wireguard.iface.WgInterfaceService;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -8,9 +8,12 @@ import com.wireguard.external.network.Subnet;
 import com.wireguard.external.shell.CommandExecutionException;
 import com.wireguard.external.wireguard.ParsingException;
 import com.wireguard.external.wireguard.PeerCreationRequest;
+import com.wireguard.external.wireguard.PeerUpdateRequest;
 import com.wireguard.external.wireguard.peer.CreatedPeer;
 import com.wireguard.external.wireguard.peer.WgPeer;
 import com.wireguard.external.wireguard.peer.WgPeerService;
+import com.wireguard.utils.IpUtils;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -26,10 +29,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.net.Inet4Address;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RestController
@@ -83,9 +84,55 @@ public class PeerController {
         return pagePeerToPageDTOPeerDTO(peers);
     }
 
+    @Operation(summary = "Update peer by public key", description = "Update peer by public key. " +
+            "Do not provide fields that you do not want to change.")
+    @Parameter(name = "currentPublicKey", description = "Public key of peer", required = true)
+    @Parameter(name = "newPublicKey", description = "New public key of peer")
+    @Parameter(name = "presharedKey", description = "Preshared key or empty if no psk required (Empty if not provided)",
+            allowEmptyValue = true)
+    @Parameter(name = "allowedIps", description = "New ips of peer (Exists will be replaced)  Example: 10.0.0.11/32",
+            array = @ArraySchema(arraySchema = @Schema(implementation = String.class), uniqueItems=true), allowEmptyValue = true)
+    @Parameter(name = "persistentKeepalive", description = "New persistent keepalive interval in seconds (0 if not provided)", schema = @Schema(implementation = Integer.class, defaultValue = "0", example = "0", minimum = "0", maximum = "65535"))
+    @Parameter(name = "peerUpdateRequestDTO", hidden = true)
+    @RequestMapping(value = "/peer/update", method = RequestMethod.PATCH)
+    public WgPeerDTO updatePeer(
+        PeerUpdateRequestDTO peerUpdateRequestDTO
+    ){
+        try {
+            System.out.println(peerUpdateRequestDTO);
+            System.out.println(peerUpdateRequestDTOToPeerUpdateRequest(peerUpdateRequestDTO));
+            WgPeer wgPeer = wgPeerService.updatePeer(
+                    peerUpdateRequestDTOToPeerUpdateRequest(peerUpdateRequestDTO));
+            return WgPeerDTO.from(wgPeer);
+        } catch (IllegalArgumentException | NoSuchElementException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+
+    private PeerUpdateRequest peerUpdateRequestDTOToPeerUpdateRequest(PeerUpdateRequestDTO peerUpdateRequestDTO){
+        Set<Subnet> allowedV4Ips = null;
+        Set<String> allowedV6Ips = null;
+        if (peerUpdateRequestDTO.getAllowedIps()!=null){
+            Map<IpUtils.IpType, Set<String>> allowedIps = IpUtils.splitIpv4AndIpv6(peerUpdateRequestDTO.getAllowedIps());
+            allowedV4Ips = allowedIps.get(IpUtils.IpType.IPV4).stream().map(Subnet::valueOf).collect(Collectors.toSet());
+            allowedV6Ips = allowedIps.get(IpUtils.IpType.IPV6);
+        }
+
+        PeerUpdateRequest peerUpdateRequest = new PeerUpdateRequest(
+                peerUpdateRequestDTO.getCurrentPublicKey(),
+                peerUpdateRequestDTO.getNewPublicKey(),
+                peerUpdateRequestDTO.getPresharedKey(),
+                allowedV4Ips,
+                allowedV6Ips,
+                peerUpdateRequestDTO.getEndpoint(),
+                peerUpdateRequestDTO.getPersistentKeepalive()
+        );
+        return peerUpdateRequest;
+    }
+
     private PageDTO<WgPeerDTO> pagePeerToPageDTOPeerDTO(Page<WgPeer> peers){
         List<WgPeerDTO> peerDTOs = peers.getContent().stream().map(WgPeerDTO::from).collect(Collectors.toList());
-        return new PageDTO<>(peers.getTotalPages()-1, peers.getNumber(), peerDTOs);
+        return new PageDTO<>(peers.getTotalPages(), peers.getNumber(), peers.getSize(), peerDTOs);
     }
 
 
@@ -101,6 +148,7 @@ public class PeerController {
             return Sort.by(direction, keys[0]);
         }
     }
+
 
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK",

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -222,7 +222,10 @@ public class PeerController {
                 peerCreationRequestDTO.getPublicKey(),
                 peerCreationRequestDTO.getPresharedKey(),
                 peerCreationRequestDTO.getPrivateKey(),
-                peerCreationRequestDTO.getAllowedIps().stream().map(Subnet::valueOf).collect(Collectors.toSet()),
+                IpUtils.stringToSubnetSet(
+                        Optional.ofNullable(
+                                peerCreationRequestDTO.getAllowedIps()
+                        ).orElseGet(Set::of)),
                 peerCreationRequestDTO.getPersistentKeepalive(),
                 countOfIpsToGenerate
         );

--- a/src/main/java/com/wireguard/api/peer/PeerCreationRequestDTO.java
+++ b/src/main/java/com/wireguard/api/peer/PeerCreationRequestDTO.java
@@ -7,7 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 @AllArgsConstructor

--- a/src/main/java/com/wireguard/api/peer/PeerCreationRequestDTO.java
+++ b/src/main/java/com/wireguard/api/peer/PeerCreationRequestDTO.java
@@ -25,10 +25,4 @@ public class PeerCreationRequestDTO {
     @Max(65535)
     private final Integer persistentKeepalive;
 
-    public Set<String> getAllowedIps() {
-        if (allowedIps == null) {
-            return new HashSet<>();
-        }
-        return allowedIps;
-    }
 }

--- a/src/main/java/com/wireguard/api/peer/PeerUpdateRequestDTO.java
+++ b/src/main/java/com/wireguard/api/peer/PeerUpdateRequestDTO.java
@@ -9,7 +9,7 @@ import java.util.Set;
 @AllArgsConstructor
 public class PeerUpdateRequestDTO {
     private final String currentPublicKey;
-    private final String NewPublicKey;
+    private final String newPublicKey;
     private final String presharedKey;
     private final Set<String> allowedIps;
     private final String endpoint;

--- a/src/main/java/com/wireguard/api/peer/PeerUpdateRequestDTO.java
+++ b/src/main/java/com/wireguard/api/peer/PeerUpdateRequestDTO.java
@@ -1,0 +1,17 @@
+package com.wireguard.api.peer;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Set;
+
+@Data
+@AllArgsConstructor
+public class PeerUpdateRequestDTO {
+    private final String currentPublicKey;
+    private final String NewPublicKey;
+    private final String presharedKey;
+    private final Set<String> allowedIps;
+    private final String endpoint;
+    private final Integer persistentKeepalive;
+}

--- a/src/main/java/com/wireguard/api/peer/WgPeerDTO.java
+++ b/src/main/java/com/wireguard/api/peer/WgPeerDTO.java
@@ -26,7 +26,7 @@ public class WgPeerDTO {
         wgPeerDTO.publicKey = wgPeer.getPublicKey();
         wgPeerDTO.presharedKey = wgPeer.getPresharedKey();
         wgPeerDTO.endpoint = wgPeer.getEndpoint();
-        wgPeerDTO.allowedSubnets = wgPeer.getAllowedSubnets().getAll();
+        wgPeerDTO.allowedSubnets = wgPeer.getAllowedSubnets().getAllStrings();
         wgPeerDTO.latestHandshake = wgPeer.getLatestHandshake();
         wgPeerDTO.transferRx = wgPeer.getTransferRx();
         wgPeerDTO.transferTx = wgPeer.getTransferTx();

--- a/src/main/java/com/wireguard/external/network/ISubnet.java
+++ b/src/main/java/com/wireguard/external/network/ISubnet.java
@@ -1,21 +1,16 @@
 package com.wireguard.external.network;
 
-import java.util.List;
+import java.math.BigInteger;
 
-public interface ISubnet extends Comparable<ISubnet> {
+public interface ISubnet {
 
 
-    long getIpCount();
+    BigInteger getIpCount();
     byte[] getFirstIpBytes();
     byte[] getLastIpBytes();
-    long getLastIpNumeric();
-    long getFirstIpNumeric();
-    List<Integer> getIp();
     String getIpString();
     String getFirstIpString();
     String getLastIpString();
-    List<Integer> getFirstIp();
-    List<Integer> getLastIp();
 
 
 }

--- a/src/main/java/com/wireguard/external/network/ISubnetSolver.java
+++ b/src/main/java/com/wireguard/external/network/ISubnetSolver.java
@@ -1,35 +1,12 @@
 package com.wireguard.external.network;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
 public interface ISubnetSolver {
 
-    Subnet obtainFree(int mask);
-
-    void obtain(Subnet subnet) throws AlreadyUsedException;
-
     void obtainIp(String ip);
-
-    void release(Subnet subnet);
-
-    boolean isUsed(Subnet subnet);
 
     long getAvailableIpsCount();
 
     long getTotalIpsCount();
 
     long getUsedIpsCount();
-
-    @Data
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
-    class IpRange {
-        private long least;
-        private long biggest;
-        public long getIpsCount(){
-            return biggest - least + 1;
-        }
-    }
-
 }

--- a/src/main/java/com/wireguard/external/network/IV4SubnetSolver.java
+++ b/src/main/java/com/wireguard/external/network/IV4SubnetSolver.java
@@ -1,0 +1,29 @@
+package com.wireguard.external.network;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public interface IV4SubnetSolver extends ISubnetSolver{
+
+    Subnet obtainFree(int mask);
+
+    void obtain(Subnet subnet) throws AlreadyUsedException;
+
+    void obtainIp(String ip);
+
+    void release(Subnet subnet);
+
+    boolean isUsed(Subnet subnet);
+
+    @Data
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    class IpRange {
+        private long least;
+        private long biggest;
+        public long getIpsCount(){
+            return biggest - least + 1;
+        }
+    }
+
+}

--- a/src/main/java/com/wireguard/external/network/NetworkInterfaceData.java
+++ b/src/main/java/com/wireguard/external/network/NetworkInterfaceData.java
@@ -8,14 +8,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-public class NetworkInterfaceDTO {
+public class NetworkInterfaceData {
     @Getter  private final String name;
 
 
     private final Set<Subnet> ipv4Subnets = new HashSet<>();
     private final Set<Inet4Address> ipv4Addresses = new HashSet<>();
 
-    public NetworkInterfaceDTO(String name){
+    public NetworkInterfaceData(String name){
         this.name = name;
     }
 
@@ -29,7 +29,7 @@ public class NetworkInterfaceDTO {
 
     public void addInterfaceAddress(InterfaceAddress interfaceAddress){
         if (interfaceAddress.getAddress() instanceof Inet4Address)
-            ipv4Subnets.add(Subnet.valueOf((Inet4Address) interfaceAddress.getAddress(),
+            ipv4Subnets.add(Subnet.valueOf(interfaceAddress.getAddress(),
                     interfaceAddress.getNetworkPrefixLength()));
         else throw new IllegalArgumentException("Only IPv4 addresses are supported");
     }

--- a/src/main/java/com/wireguard/external/network/QueuedSubnetSolver.java
+++ b/src/main/java/com/wireguard/external/network/QueuedSubnetSolver.java
@@ -8,14 +8,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-public class QueuedSubnetSolver implements ISubnetSolver{
+public class QueuedSubnetSolver implements IV4SubnetSolver {
 
-    private final ISubnetSolver subnetSolver;
+    private final IV4SubnetSolver subnetSolver;
 
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
-    public QueuedSubnetSolver(ISubnetSolver subnetSolver){
+    public QueuedSubnetSolver(IV4SubnetSolver subnetSolver){
         this.subnetSolver = subnetSolver;
     }
 

--- a/src/main/java/com/wireguard/external/network/Subnet.java
+++ b/src/main/java/com/wireguard/external/network/Subnet.java
@@ -4,11 +4,12 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.springframework.util.Assert;
 
+import java.math.BigInteger;
 import java.net.InetAddress;
 import java.util.List;
 
 @EqualsAndHashCode
-public class Subnet implements ISubnet {
+public class Subnet implements ISubnet, Comparable<Subnet> {
     private final byte[] ip;
     private final byte[] mask;
     @Getter private final int numericMask;
@@ -32,8 +33,8 @@ public class Subnet implements ISubnet {
     }
 
     @Override
-    public long getIpCount(){
-        return (long) Math.pow(2, 32 - numericMask);
+    public BigInteger getIpCount(){
+        return  BigInteger.valueOf((long) Math.pow(2, 32 - numericMask));
     }
 
     @Override
@@ -60,12 +61,10 @@ public class Subnet implements ISubnet {
     }
 
 
-    @Override
     public long getLastIpNumeric(){
         return byteToNumericIp(getLastIpBytes());
     }
 
-    @Override
     public long getFirstIpNumeric(){
         return byteToNumericIp(getFirstIpBytes());
     }
@@ -77,11 +76,6 @@ public class Subnet implements ISubnet {
                 byteToUnsignedInt(ip[2]),
                 byteToUnsignedInt(ip[3])
         );
-    }
-
-    @Override
-    public List<Integer> getIp(){
-        return byteIpToIntList(ip);
     }
 
     private String bytesIpToString(byte[] ip){
@@ -108,15 +102,6 @@ public class Subnet implements ISubnet {
         return bytesIpToString(getLastIpBytes());
     }
 
-    @Override
-    public List<Integer> getFirstIp(){
-        return byteIpToIntList(getFirstIpBytes());
-    }
-
-    @Override
-    public List<Integer> getLastIp(){
-        return byteIpToIntList(getLastIpBytes());
-    }
 
     private long byteToNumericIp(byte[] ip){
         long count = 0;
@@ -168,7 +153,7 @@ public class Subnet implements ISubnet {
 
 
     @Override
-    public int compareTo(ISubnet o) {
+    public int compareTo(Subnet o) {
         return Long.compare(getFirstIpNumeric(), o.getFirstIpNumeric());
     }
 }

--- a/src/main/java/com/wireguard/external/network/SubnetSolver.java
+++ b/src/main/java/com/wireguard/external/network/SubnetSolver.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.List;
 
 
-public class SubnetSolver implements ISubnetSolver {
+public class SubnetSolver implements IV4SubnetSolver {
 
     private static final Logger logger = LoggerFactory.getLogger(SubnetSolver.class);
 

--- a/src/main/java/com/wireguard/external/network/SubnetSolver.java
+++ b/src/main/java/com/wireguard/external/network/SubnetSolver.java
@@ -1,6 +1,5 @@
 package com.wireguard.external.network;
 
-import com.wireguard.external.wireguard.peer.WgPeerCreator;
 import lombok.Getter;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
@@ -41,7 +40,7 @@ public class SubnetSolver implements ISubnetSolver {
             int requestedSubnetIndex = calculatePreviousRangeIndex(findFirstGreater(requestedSubnet.getFirstIpNumeric()));
             availableRanges.remove(requestedSubnetIndex);
             availableRanges.addAll(requestedSubnetIndex, insertSubnetIntoIpRange(requestedSubnet, subnetAndRange.getRight()));
-            availableIpsCount -= requestedSubnet.getIpCount();
+            availableIpsCount -= requestedSubnet.getIpCount().longValue();
             logger.debug("Obtained free subnet " + requestedSubnet + " from range " + subnetAndRange.getRight());
             return requestedSubnet;
         } else {
@@ -88,7 +87,7 @@ public class SubnetSolver implements ISubnetSolver {
         if (isIpsInRange(firstAddress, lastAddress, availableRange)){
             availableRanges.remove(currRangeIndex);
             availableRanges.addAll(currRangeIndex, insertSubnetIntoIpRange(subnet, availableRange));
-            availableIpsCount -= subnet.getIpCount();
+            availableIpsCount -= subnet.getIpCount().longValue();
             logger.debug("Obtained subnet " + subnet + " from range " + availableRange);
         } else {
             throw new AlreadyUsedException("Subnet " + subnet + " is is already used");
@@ -120,7 +119,7 @@ public class SubnetSolver implements ISubnetSolver {
         }
         if (getAvailableIpsCount()==0L){
             availableRanges.add(new IpRange(firstAddress, lastAddress));
-            availableIpsCount += subnet.getIpCount();
+            availableIpsCount += subnet.getIpCount().longValue();
             return;
         }
 
@@ -141,7 +140,7 @@ public class SubnetSolver implements ISubnetSolver {
             } else {
                 availableRanges.add(leastIndex, new IpRange(firstAddress, lastAddress));
             }
-            availableIpsCount += subnet.getIpCount();
+            availableIpsCount += subnet.getIpCount().longValue();
             logger.debug("Released subnet " + subnet);
         } else {
             throw new UncheckedIOException(new IOException("This subnet is not used"));

--- a/src/main/java/com/wireguard/external/network/SubnetV6.java
+++ b/src/main/java/com/wireguard/external/network/SubnetV6.java
@@ -1,0 +1,67 @@
+package com.wireguard.external.network;
+
+import com.googlecode.ipv6.IPv6Network;
+
+import java.math.BigInteger;
+
+public class SubnetV6 implements ISubnet, Comparable<SubnetV6>{
+
+    private final IPv6Network address;
+
+    public SubnetV6(IPv6Network address) {
+        this.address = address;
+    }
+
+    public static SubnetV6 valueOf(String subnet) {
+        return new SubnetV6(IPv6Network.fromString(subnet));
+    }
+
+    @Override
+    public BigInteger getIpCount() {
+        return address.getFirst().toBigInteger().subtract(address.getLast().toBigInteger());
+    }
+
+    @Override
+    public byte[] getFirstIpBytes() {
+        return address.getFirst().toByteArray();
+    }
+
+    @Override
+    public byte[] getLastIpBytes() {
+        return address.getLast().toByteArray();
+    }
+
+    public BigInteger getLastIpNumeric() {
+        return address.getLast().toBigInteger();
+    }
+
+    public BigInteger getFirstIpNumeric() {
+        return address.getFirst().toBigInteger();
+    }
+
+
+    @Override
+    public String getIpString() {
+        return address.toString();
+    }
+
+    @Override
+    public String getFirstIpString() {
+        return address.getFirst().toString();
+    }
+
+    @Override
+    public String getLastIpString() {
+        return address.getLast().toString();
+    }
+
+    @Override
+    public int compareTo(SubnetV6 o) {
+        return getFirstIpNumeric().compareTo(o.getFirstIpNumeric());
+    }
+
+    @Override
+    public String toString() {
+        return getIpString();
+    }
+}

--- a/src/main/java/com/wireguard/external/wireguard/EmptyPeerCreationRequest.java
+++ b/src/main/java/com/wireguard/external/wireguard/EmptyPeerCreationRequest.java
@@ -1,6 +1,5 @@
 package com.wireguard.external.wireguard;
 
-import com.wireguard.external.network.Subnet;
 import lombok.EqualsAndHashCode;
 
 import java.util.Set;

--- a/src/main/java/com/wireguard/external/wireguard/Paging.java
+++ b/src/main/java/com/wireguard/external/wireguard/Paging.java
@@ -69,9 +69,6 @@ public class Paging<T> {
         ArrayList<T> sorted = sort(pageable.getSort(), new ArrayList<T>(list));
         PagedListHolder<T> page = new PagedListHolder<>(sorted);
         page.setPageSize(pageable.getPageSize());
-        if (pageable.getPageNumber() >= page.getPageCount()) {
-            throw new PageOutOfRangeException(pageable.getPageNumber(), page.getPageCount()-1);
-        }
         page.setPage(pageable.getPageNumber());
         return new PageImpl<T>(new ArrayList<>(page.getPageList()), pageable, list.size());
     }

--- a/src/main/java/com/wireguard/external/wireguard/PeerCreationRequest.java
+++ b/src/main/java/com/wireguard/external/wireguard/PeerCreationRequest.java
@@ -1,5 +1,6 @@
 package com.wireguard.external.wireguard;
 
+import com.wireguard.external.network.ISubnet;
 import com.wireguard.external.network.Subnet;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -14,7 +15,7 @@ public class PeerCreationRequest {
     private final String publicKey;
     private final String presharedKey;
     private final String privateKey;
-    private Set<Subnet> allowedIps;
+    private Set<ISubnet> allowedIps;
     private final Integer persistentKeepalive;
     private final int countOfIpsToGenerate;
 

--- a/src/main/java/com/wireguard/external/wireguard/PeerCreationRequest.java
+++ b/src/main/java/com/wireguard/external/wireguard/PeerCreationRequest.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.List;
 import java.util.Set;
 
 @AllArgsConstructor
@@ -15,7 +14,9 @@ public class PeerCreationRequest {
     private final String publicKey;
     private final String presharedKey;
     private final String privateKey;
-    private final Set<Subnet> allowedIps;
+    private Set<Subnet> allowedIps;
     private final Integer persistentKeepalive;
     private final int countOfIpsToGenerate;
+
+
 }

--- a/src/main/java/com/wireguard/external/wireguard/PeerUpdateRequest.java
+++ b/src/main/java/com/wireguard/external/wireguard/PeerUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.wireguard.external.wireguard;
+
+import com.wireguard.external.network.Subnet;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Set;
+
+@Data
+@AllArgsConstructor
+public class PeerUpdateRequest {
+    private final String currentPublicKey;
+    private final String NewPublicKey;
+    private final String presharedKey;
+    private final Set<Subnet> allowedV4Ips;
+    private final Set<String> allowedV6Ips;
+    private final String endpoint;
+    private final Integer persistentKeepalive;
+
+}

--- a/src/main/java/com/wireguard/external/wireguard/PeerUpdateRequest.java
+++ b/src/main/java/com/wireguard/external/wireguard/PeerUpdateRequest.java
@@ -1,9 +1,6 @@
 package com.wireguard.external.wireguard;
 
-import com.wireguard.external.network.Subnet;
-import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Null;
+import com.wireguard.external.network.ISubnet;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -13,10 +10,9 @@ import java.util.Set;
 @AllArgsConstructor
 public class PeerUpdateRequest {
     private final String currentPublicKey;
-    private final String NewPublicKey;
+    private final String newPublicKey;
     private final String presharedKey;
-    private final Set<Subnet> allowedV4Ips;
-    private final Set<String> allowedV6Ips;
+    private final Set<ISubnet> allowedIps;
     private final String endpoint;
     private final Integer persistentKeepalive;
 

--- a/src/main/java/com/wireguard/external/wireguard/SubnetService.java
+++ b/src/main/java/com/wireguard/external/wireguard/SubnetService.java
@@ -1,0 +1,95 @@
+package com.wireguard.external.wireguard;
+
+import com.wireguard.external.network.ISubnet;
+import com.wireguard.external.network.IV4SubnetSolver;
+import com.wireguard.external.network.Subnet;
+import com.wireguard.external.network.SubnetV6;
+import com.wireguard.external.shell.StreamToStringConverter;
+import com.wireguard.external.wireguard.peer.PeerCreationRules;
+import com.wireguard.external.wireguard.peer.WgPeer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+@Service
+@Component
+public class SubnetService {
+
+    PeerCreationRules peerCreationRules;
+    IV4SubnetSolver v4SubnetSolver;
+
+    @Autowired
+    public SubnetService(PeerCreationRules peerCreationRules, IV4SubnetSolver v4SubnetSolver) {
+        this.peerCreationRules = peerCreationRules;
+        this.v4SubnetSolver = v4SubnetSolver;
+    }
+
+    public Set<Subnet> generateV4(int countOfIpsToGenerate, int mask) {
+        Set<Subnet> subnets = new HashSet<>();
+        releaseIfException(subnets, (s) -> {
+            for (int i = 0; i < countOfIpsToGenerate; i++) {
+                subnets.add(v4SubnetSolver.obtainFree(mask));
+            }
+        });
+        return Collections.unmodifiableSet(subnets);
+    }
+
+    public Set<Subnet> generateV4(int countOfIpsToGenerate) {
+        return generateV4(countOfIpsToGenerate, peerCreationRules.getDefaultMask());
+    }
+
+    public Set<SubnetV6> generateV6(int countOfIpsToGenerate, int mask) {
+        throw new UnsupportedOperationException("It doesn't support yet");
+    }
+
+    private void releaseIfException(Set<? extends ISubnet> subnets, Consumer<Set<? extends ISubnet>> consumer) {
+        try{
+            consumer.accept(subnets);
+        } catch (Exception e){
+            release(subnets);
+            throw e;
+        }
+    }
+
+    public void release(Set<? extends ISubnet> subnets) {
+        subnets.forEach((subnet) -> {
+            if (subnet instanceof Subnet) {
+                v4SubnetSolver.release((Subnet) subnet);
+            } else if (subnet instanceof SubnetV6) {
+
+            }
+        });
+    }
+
+    public void obtain(Set<? extends ISubnet> subnets) {
+        Set<ISubnet> obtainedSubnets = new HashSet<>();
+        releaseIfException(obtainedSubnets, (s) -> {
+            subnets.forEach((subnet) -> {
+                if (subnet instanceof Subnet){
+                    v4SubnetSolver.obtain((Subnet) subnet);
+                } else if (subnet instanceof SubnetV6){
+
+                }
+                obtainedSubnets.add(subnet);
+            });
+        });
+    }
+
+    public void applyState(Set<? extends ISubnet> oldState, Set<? extends ISubnet> newState) {
+        Set<ISubnet> subnetsToRelease = new HashSet<>(oldState);
+        subnetsToRelease.removeAll(newState);
+        release(subnetsToRelease);
+        Set<ISubnet> subnetsToObtain = new HashSet<>(newState);
+        subnetsToObtain.removeAll(oldState);
+        obtain(subnetsToObtain);
+    }
+
+
+}

--- a/src/main/java/com/wireguard/external/wireguard/WgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/WgTool.java
@@ -122,7 +122,8 @@ public class WgTool {
                 new Argument("preshared-key",
                         peer.getPresharedKey().isEmpty() ? null : filePath),
                 new Argument("allowed-ips", peer.getAllowedSubnets().toString()),
-                new Argument("persistent-keepalive", String.valueOf(peer.getPersistentKeepalive()))
+                new Argument("persistent-keepalive", String.valueOf(peer.getPersistentKeepalive())),
+                new Argument("endpoint", peer.getEndpoint())
         );
         appendArgumentsIfPresentAndNotEmpty(arguments, command);
 
@@ -188,6 +189,4 @@ public class WgTool {
         run(WG_DEL_PEER_COMMAND.formatted(interfaceName, publicKey), true);
         saveConfig(interfaceName);
     }
-
-
 }

--- a/src/main/java/com/wireguard/external/wireguard/config/Config.java
+++ b/src/main/java/com/wireguard/external/wireguard/config/Config.java
@@ -29,7 +29,7 @@ public class Config {
 
 
     @Bean
-    public ISubnetSolver ipResolver(NetworkInterfaceDTO wgInterface) {
+    public IV4SubnetSolver ipResolver(NetworkInterfaceData wgInterface) {
 
         logger.info("Configuring SubnetSolver...");
         Subnet interfaceSubnet = wgInterface.getCidrV4Address().stream().findFirst().orElseThrow(
@@ -71,7 +71,7 @@ public class Config {
 
     @Profile("prod")
     @Bean
-    public NetworkInterfaceDTO wgInterface(
+    public NetworkInterfaceData wgInterface(
             @Value("${wg.interface.name}") String interfaceName
     ) throws SocketException {
         NetworkInterface networkInterface = NetworkInterface.getByName(interfaceName);
@@ -79,32 +79,32 @@ public class Config {
             logger.error("Network interface {} not found", interfaceName);
             throw new RuntimeException("Network interface not found");
         }
-        NetworkInterfaceDTO networkInterfaceDTO = new NetworkInterfaceDTO(interfaceName);
+        NetworkInterfaceData networkInterfaceData = new NetworkInterfaceData(interfaceName);
         networkInterface.getInterfaceAddresses().stream()
                         .filter(interfaceAddress -> interfaceAddress.getAddress() instanceof Inet4Address)
-                        .findFirst().ifPresentOrElse( networkInterfaceDTO::addInterfaceAddress,
+                        .findFirst().ifPresentOrElse( networkInterfaceData::addInterfaceAddress,
                             () -> {
                                 logger.error("Network interface {} has no IPv4 address", interfaceName);
                                 throw new RuntimeException("Network interface %s has no IPv4 address".formatted(interfaceName));
                             });
         networkInterface.getInetAddresses().asIterator().forEachRemaining(
                 inetAddress -> {
-                    if (inetAddress instanceof Inet4Address) networkInterfaceDTO.addAddress((Inet4Address) inetAddress);
+                    if (inetAddress instanceof Inet4Address) networkInterfaceData.addAddress((Inet4Address) inetAddress);
                 });
-        return networkInterfaceDTO;
+        return networkInterfaceData;
     }
 
     @Profile("test")
     @Bean
-    public NetworkInterfaceDTO wgInterfaceTest(
+    public NetworkInterfaceData wgInterfaceTest(
             @Value("${wg.interface.name}") String interfaceName,
             @Value("${wg.test.interface.cidr}") String cidr,
             @Value("${wg.test.interface.interfaceIp}") String interfaceIp
     ) throws UnknownHostException {
-        NetworkInterfaceDTO networkInterfaceDTO = new NetworkInterfaceDTO(interfaceName);
+        NetworkInterfaceData networkInterfaceData = new NetworkInterfaceData(interfaceName);
         Subnet subnet = Subnet.valueOf(cidr);
-        networkInterfaceDTO.addInterfaceAddress(subnet);
-        networkInterfaceDTO.addAddress((Inet4Address) Inet4Address.getByName(interfaceIp));
-        return networkInterfaceDTO;
+        networkInterfaceData.addInterfaceAddress(subnet);
+        networkInterfaceData.addAddress((Inet4Address) Inet4Address.getByName(interfaceIp));
+        return networkInterfaceData;
     }
 }

--- a/src/main/java/com/wireguard/external/wireguard/iface/CachedWgInterfaceService.java
+++ b/src/main/java/com/wireguard/external/wireguard/iface/CachedWgInterfaceService.java
@@ -2,7 +2,7 @@ package com.wireguard.external.wireguard.iface;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.wireguard.external.network.NetworkInterfaceDTO;
+import com.wireguard.external.network.NetworkInterfaceData;
 import com.wireguard.external.wireguard.WgTool;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -16,7 +16,7 @@ public class CachedWgInterfaceService extends WgInterfaceService {
     private final int REFRESH_INTERVAL_SECONDS = 300;
 
     LoadingCache<String, WgInterface> wgInterfaceCache;
-    public CachedWgInterfaceService(NetworkInterfaceDTO wgInterface, WgTool wgTool) {
+    public CachedWgInterfaceService(NetworkInterfaceData wgInterface, WgTool wgTool) {
         super(wgInterface, wgTool);
         wgInterfaceCache = Caffeine.newBuilder()
                 .refreshAfterWrite(REFRESH_INTERVAL_SECONDS, TimeUnit.SECONDS)

--- a/src/main/java/com/wireguard/external/wireguard/iface/CachedWgInterfaceService.java
+++ b/src/main/java/com/wireguard/external/wireguard/iface/CachedWgInterfaceService.java
@@ -1,6 +1,5 @@
 package com.wireguard.external.wireguard.iface;
 
-import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.wireguard.external.network.NetworkInterfaceDTO;

--- a/src/main/java/com/wireguard/external/wireguard/iface/WgInterfaceService.java
+++ b/src/main/java/com/wireguard/external/wireguard/iface/WgInterfaceService.java
@@ -1,6 +1,6 @@
 package com.wireguard.external.wireguard.iface;
 
-import com.wireguard.external.network.NetworkInterfaceDTO;
+import com.wireguard.external.network.NetworkInterfaceData;
 import com.wireguard.external.wireguard.WgTool;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Component;
 @ConditionalOnProperty(value = "wg.cache.enabled", havingValue = "false")
 public class WgInterfaceService {
 
-    private final NetworkInterfaceDTO wgInterface;
+    private final NetworkInterfaceData wgInterface;
     private final WgTool wgTool;
 
-    public WgInterfaceService(NetworkInterfaceDTO wgInterface, WgTool wgTool) {
+    public WgInterfaceService(NetworkInterfaceData wgInterface, WgTool wgTool) {
         this.wgInterface = wgInterface;
         this.wgTool = wgTool;
     }

--- a/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
@@ -1,21 +1,15 @@
 package com.wireguard.external.wireguard.peer;
 
-import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
-import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.wireguard.external.network.ISubnetSolver;
 import com.wireguard.external.network.NetworkInterfaceDTO;
-import com.wireguard.external.network.SubnetSolver;
 import com.wireguard.external.wireguard.RepositoryPageable;
-import com.wireguard.external.wireguard.Specification;
 import com.wireguard.external.wireguard.WgTool;
 import com.wireguard.external.wireguard.peer.spec.FindByPublicKey;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -34,7 +28,7 @@ public class CachedWgPeerRepository extends WgPeerRepository implements Reposito
     @Autowired
     public CachedWgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface, ISubnetSolver subnetSolver,
                                   @Value("${wg.cache.update-interval}") int cacheUpdateIntervalSeconds) {
-        super(wgTool, wgInterface);
+        super(wgTool, wgInterface, subnetSolver);
         UPDATE_INTERVAL_SECONDS = cacheUpdateIntervalSeconds;
         wgPeerCache = Caffeine.newBuilder()
                 .refreshAfterWrite(UPDATE_INTERVAL_SECONDS, TimeUnit.SECONDS)

--- a/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
@@ -28,7 +28,7 @@ public class CachedWgPeerRepository extends WgPeerRepository implements Reposito
     @Autowired
     public CachedWgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface, ISubnetSolver subnetSolver,
                                   @Value("${wg.cache.update-interval}") int cacheUpdateIntervalSeconds) {
-        super(wgTool, wgInterface, subnetSolver);
+        super(wgTool, wgInterface);
         UPDATE_INTERVAL_SECONDS = cacheUpdateIntervalSeconds;
         wgPeerCache = Caffeine.newBuilder()
                 .refreshAfterWrite(UPDATE_INTERVAL_SECONDS, TimeUnit.SECONDS)

--- a/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
@@ -2,8 +2,8 @@ package com.wireguard.external.wireguard.peer;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.wireguard.external.network.ISubnetSolver;
-import com.wireguard.external.network.NetworkInterfaceDTO;
+import com.wireguard.external.network.IV4SubnetSolver;
+import com.wireguard.external.network.NetworkInterfaceData;
 import com.wireguard.external.wireguard.RepositoryPageable;
 import com.wireguard.external.wireguard.WgTool;
 import com.wireguard.external.wireguard.peer.spec.FindByPublicKey;
@@ -26,7 +26,7 @@ public class CachedWgPeerRepository extends WgPeerRepository implements Reposito
     private final int UPDATE_INTERVAL_SECONDS;
 
     @Autowired
-    public CachedWgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface, ISubnetSolver subnetSolver,
+    public CachedWgPeerRepository(WgTool wgTool, NetworkInterfaceData wgInterface, IV4SubnetSolver subnetSolver,
                                   @Value("${wg.cache.update-interval}") int cacheUpdateIntervalSeconds) {
         super(wgTool, wgInterface);
         UPDATE_INTERVAL_SECONDS = cacheUpdateIntervalSeconds;
@@ -57,7 +57,7 @@ public class CachedWgPeerRepository extends WgPeerRepository implements Reposito
         super.update(oldT, newT);
     }
 
-    private void updateCache(ISubnetSolver subnetSolver) {
+    private void updateCache(IV4SubnetSolver subnetSolver) {
         wgPeerCache.invalidateAll();
         for (WgPeer wgPeer : super.getAll()) {
             wgPeerCache.put(wgPeer.getPublicKey(), wgPeer);

--- a/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
@@ -28,7 +28,7 @@ public class CachedWgPeerRepository extends WgPeerRepository implements Reposito
     @Autowired
     public CachedWgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface, ISubnetSolver subnetSolver,
                                   @Value("${wg.cache.update-interval}") int cacheUpdateIntervalSeconds) {
-        super(wgTool, wgInterface, subnetSolver);
+        super(wgTool, wgInterface);
         UPDATE_INTERVAL_SECONDS = cacheUpdateIntervalSeconds;
         wgPeerCache = Caffeine.newBuilder()
                 .refreshAfterWrite(UPDATE_INTERVAL_SECONDS, TimeUnit.SECONDS)
@@ -51,6 +51,8 @@ public class CachedWgPeerRepository extends WgPeerRepository implements Reposito
 
     @Override
     public void update(WgPeer oldT, WgPeer newT) {
+        if (!oldT.getPublicKey().equals(newT.getPublicKey()))
+            wgPeerCache.invalidate(oldT.getPublicKey());
         wgPeerCache.put(newT.getPublicKey(), newT);
         super.update(oldT, newT);
     }

--- a/src/main/java/com/wireguard/external/wireguard/peer/CreatedPeer.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/CreatedPeer.java
@@ -1,5 +1,6 @@
 package com.wireguard.external.wireguard.peer;
 
+import com.wireguard.external.network.ISubnet;
 import com.wireguard.external.network.Subnet;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -16,6 +17,6 @@ public class CreatedPeer {
     private String publicKey;
     private String presharedKey;
     private String privateKey;
-    private Set<Subnet> allowedSubnets;
+    private Set<ISubnet> allowedSubnets;
     private int persistentKeepalive;
 }

--- a/src/main/java/com/wireguard/external/wireguard/peer/PeerCreationRules.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/PeerCreationRules.java
@@ -1,0 +1,19 @@
+package com.wireguard.external.wireguard.peer;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class PeerCreationRules {
+
+
+    private final int defaultMask;
+
+    @Autowired
+    public PeerCreationRules(@Value("${wg.interface.default.mask}") int defaultMask) {
+        this.defaultMask = defaultMask;
+    }
+}

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeer.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeer.java
@@ -13,7 +13,7 @@ import java.util.Set;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class WgPeer implements Comparable<WgPeer> {
-    private String publicKey;
+    private final String publicKey;
     private String presharedKey;
     private String endpoint;
     private AllowedSubnets allowedSubnets;
@@ -23,6 +23,9 @@ public class WgPeer implements Comparable<WgPeer> {
     private int persistentKeepalive;
     public static Builder publicKey(String publicKey) {
         return new Builder().publicKey(publicKey);
+    }
+    public static Builder from(WgPeer wgPeer) {
+        return new Builder().from(wgPeer);
     }
 
     @Override
@@ -145,8 +148,20 @@ public class WgPeer implements Comparable<WgPeer> {
             return this;
         }
 
+        public Builder from(WgPeer wgPeer) {
+            this.publicKey = wgPeer.publicKey;
+            this.presharedKey = wgPeer.presharedKey;
+            this.endpoint = wgPeer.endpoint;
+            this.allowedSubnets = wgPeer.allowedSubnets;
+            this.latestHandshake = wgPeer.latestHandshake;
+            this.transferRx = wgPeer.transferRx;
+            this.transferTx = wgPeer.transferTx;
+            this.persistentKeepalive = wgPeer.persistentKeepalive;
+            return this;
+        }
+
         public WgPeer build(){
-            Assert.notNull(publicKey, "Public key must not be null");
+            Assert.notNull(publicKey, "WgPeer.Builder: Public key must not be null");
             return new WgPeer(publicKey,
                     presharedKey,
                     endpoint,

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeer.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeer.java
@@ -85,6 +85,10 @@ public class WgPeer implements Comparable<WgPeer> {
 
         @Override
         public int compareTo(AllowedSubnets o) {
+            if (IPv4Subnets.isEmpty() && o.IPv4Subnets.isEmpty()){
+                return IPv6Subnets.stream().findFirst().orElse(SubnetV6.valueOf("::/128"))
+                        .compareTo(o.IPv6Subnets.stream().findFirst().orElse(SubnetV6.valueOf("::/128")));
+            }
             return IPv4Subnets.stream().findFirst().orElse(Subnet.valueOf("0.0.0.0/32"))
                     .compareTo(o.IPv4Subnets.stream().findFirst().orElse(Subnet.valueOf("0.0.0.0/32")));
         }

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerGenerator.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerGenerator.java
@@ -1,5 +1,6 @@
 package com.wireguard.external.wireguard.peer;
 
+import com.wireguard.external.network.ISubnet;
 import com.wireguard.external.network.Subnet;
 import com.wireguard.external.wireguard.PeerCreationRequest;
 import com.wireguard.external.wireguard.WgTool;
@@ -33,7 +34,7 @@ public class WgPeerGenerator {
         String publicKey = peerCreationRequest.getPublicKey() == null ? wgTool.generatePublicKey(privateKey) : peerCreationRequest.getPublicKey();
         String presharedKey = peerCreationRequest.getPresharedKey() == null ? wgTool.generatePresharedKey() : peerCreationRequest.getPresharedKey();
         int persistentKeepalive = peerCreationRequest.getPersistentKeepalive() == null ? DEFAULT_PERSISTENT_KEEPALIVE : peerCreationRequest.getPersistentKeepalive();
-        Set<Subnet> allowedIps = peerCreationRequest.getAllowedIps();
+        Set<ISubnet> allowedIps = peerCreationRequest.getAllowedIps();
         logger.info("Created peer, public key: %s".formatted(publicKey.substring(0, Math.min(6, publicKey.length()))));
         return new CreatedPeer(publicKey, presharedKey, privateKey, allowedIps, persistentKeepalive);
     }

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerGenerator.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerGenerator.java
@@ -1,36 +1,30 @@
 package com.wireguard.external.wireguard.peer;
 
-import com.wireguard.external.network.*;
-import com.wireguard.external.shell.CommandExecutionException;
-import com.wireguard.external.shell.ShellRunner;
+import com.wireguard.external.network.Subnet;
 import com.wireguard.external.wireguard.PeerCreationRequest;
 import com.wireguard.external.wireguard.WgTool;
-import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.HashSet;
 import java.util.Set;
 
 @Component
-public class WgPeerCreator {
+public class WgPeerGenerator {
 
-    private static final Logger logger = LoggerFactory.getLogger(WgPeerCreator.class);
+    private static final Logger logger = LoggerFactory.getLogger(WgPeerGenerator.class);
     @Value("${wg.interface.default.mask}")
-    private final int DEFAULT_MASK_FOR_NEW_CLIENTS = 32;
+    public final int DEFAULT_MASK_FOR_NEW_CLIENTS = 32;
     @Value("${wg.interface.default.persistent_keepalive}")
     public final int DEFAULT_PERSISTENT_KEEPALIVE = 0;
 
-    private final ISubnetSolver wgSubnetSolver;
     private final WgTool wgTool;
 
     @Autowired
-    public WgPeerCreator(WgTool wgTool, ISubnetSolver wgSubnetSolver) {
+    public WgPeerGenerator(WgTool wgTool) {
         this.wgTool = wgTool;
-        this.wgSubnetSolver = wgSubnetSolver;
     }
 
 
@@ -40,26 +34,7 @@ public class WgPeerCreator {
         String presharedKey = peerCreationRequest.getPresharedKey() == null ? wgTool.generatePresharedKey() : peerCreationRequest.getPresharedKey();
         int persistentKeepalive = peerCreationRequest.getPersistentKeepalive() == null ? DEFAULT_PERSISTENT_KEEPALIVE : peerCreationRequest.getPersistentKeepalive();
         Set<Subnet> allowedIps = peerCreationRequest.getAllowedIps();
-        obtainSubnets(allowedIps);
-        for (int i = 0; i < peerCreationRequest.getCountOfIpsToGenerate(); i++) {
-            allowedIps.add(wgSubnetSolver.obtainFree(DEFAULT_MASK_FOR_NEW_CLIENTS));
-        }
         logger.info("Created peer, public key: %s".formatted(publicKey.substring(0, Math.min(6, publicKey.length()))));
         return new CreatedPeer(publicKey, presharedKey, privateKey, allowedIps, persistentKeepalive);
-
     }
-
-    private void obtainSubnets(Set<Subnet> subnets) {
-        Set<Subnet> obtainedSubnets = new HashSet<>();
-        try{
-            subnets.forEach((subnet) -> {
-                wgSubnetSolver.obtain(subnet);
-                obtainedSubnets.add(subnet);
-            });
-        } catch (Exception e){
-            obtainedSubnets.forEach(wgSubnetSolver::release);
-            throw e;
-        }
-    }
-
 }

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
@@ -1,6 +1,7 @@
 package com.wireguard.external.wireguard.peer;
 
 
+import com.wireguard.external.network.ISubnetSolver;
 import com.wireguard.external.network.NetworkInterfaceDTO;
 import com.wireguard.external.wireguard.Paging;
 import com.wireguard.external.wireguard.RepositoryPageable;
@@ -21,12 +22,14 @@ public class WgPeerRepository implements RepositoryPageable<WgPeer> {
 
     private final WgTool wgTool;
     private final NetworkInterfaceDTO wgInterface;
+    private final ISubnetSolver subnetSolver;
     private final Paging<WgPeer> paging = new Paging<>(WgPeer.class);
 
     @Autowired
-    public WgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface) {
+    public WgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface, ISubnetSolver subnetSolver) {
         this.wgTool = wgTool;
         this.wgInterface = wgInterface;
+        this.subnetSolver = subnetSolver;
     }
 
     @Override
@@ -41,7 +44,10 @@ public class WgPeerRepository implements RepositoryPageable<WgPeer> {
 
     @Override
     public void update(WgPeer oldT, WgPeer newT) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        if (!oldT.getPublicKey().equals(newT.getPublicKey())) {
+            wgTool.deletePeer(wgInterface.getName(), oldT.getPublicKey());
+        }
+        wgTool.addPeer(wgInterface.getName(), newT);
     }
 
     @Override
@@ -70,4 +76,5 @@ public class WgPeerRepository implements RepositoryPageable<WgPeer> {
         List<WgPeer> peers = getAll();
         return paging.apply(pageable, peers);
     }
+
 }

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
@@ -1,7 +1,6 @@
 package com.wireguard.external.wireguard.peer;
 
 
-import com.wireguard.external.network.ISubnetSolver;
 import com.wireguard.external.network.NetworkInterfaceDTO;
 import com.wireguard.external.wireguard.Paging;
 import com.wireguard.external.wireguard.RepositoryPageable;
@@ -22,14 +21,12 @@ public class WgPeerRepository implements RepositoryPageable<WgPeer> {
 
     private final WgTool wgTool;
     private final NetworkInterfaceDTO wgInterface;
-    private final ISubnetSolver subnetSolver;
     private final Paging<WgPeer> paging = new Paging<>(WgPeer.class);
 
     @Autowired
-    public WgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface, ISubnetSolver subnetSolver) {
+    public WgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface) {
         this.wgTool = wgTool;
         this.wgInterface = wgInterface;
-        this.subnetSolver = subnetSolver;
     }
 
     @Override

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
@@ -1,7 +1,7 @@
 package com.wireguard.external.wireguard.peer;
 
 
-import com.wireguard.external.network.NetworkInterfaceDTO;
+import com.wireguard.external.network.NetworkInterfaceData;
 import com.wireguard.external.wireguard.Paging;
 import com.wireguard.external.wireguard.RepositoryPageable;
 import com.wireguard.external.wireguard.Specification;
@@ -20,11 +20,11 @@ import java.util.stream.Collectors;
 public class WgPeerRepository implements RepositoryPageable<WgPeer> {
 
     private final WgTool wgTool;
-    private final NetworkInterfaceDTO wgInterface;
+    private final NetworkInterfaceData wgInterface;
     private final Paging<WgPeer> paging = new Paging<>(WgPeer.class);
 
     @Autowired
-    public WgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface) {
+    public WgPeerRepository(WgTool wgTool, NetworkInterfaceData wgInterface) {
         this.wgTool = wgTool;
         this.wgInterface = wgInterface;
     }

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
@@ -22,14 +22,12 @@ public class WgPeerRepository implements RepositoryPageable<WgPeer> {
 
     private final WgTool wgTool;
     private final NetworkInterfaceDTO wgInterface;
-    private final ISubnetSolver subnetSolver;
     private final Paging<WgPeer> paging = new Paging<>(WgPeer.class);
 
     @Autowired
-    public WgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface, ISubnetSolver subnetSolver) {
+    public WgPeerRepository(WgTool wgTool, NetworkInterfaceDTO wgInterface) {
         this.wgTool = wgTool;
         this.wgInterface = wgInterface;
-        this.subnetSolver = subnetSolver;
     }
 
     @Override

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerService.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerService.java
@@ -1,10 +1,10 @@
 package com.wireguard.external.wireguard.peer;
 
+import com.wireguard.external.network.ISubnetSolver;
 import com.wireguard.external.network.Subnet;
 import com.wireguard.external.shell.ShellRunner;
 import com.wireguard.external.wireguard.*;
 import com.wireguard.external.wireguard.peer.spec.FindByPublicKey;
-import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,23 +13,26 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Consumer;
+import java.util.*;
 
 @Component
 @Scope("singleton")
 public class WgPeerService {
 
     private static final Logger logger = LoggerFactory.getLogger(ShellRunner.class);
-    WgPeerCreator wgPeerCreator;
+    WgPeerGenerator peerGenerator;
     RepositoryPageable<WgPeer> wgPeerRepository;
+    ISubnetSolver wgSubnetSolver;
+    PeerCreationRules peerCreationRules;
+
 
     @Autowired
-    public WgPeerService(WgPeerCreator wgPeerCreator, RepositoryPageable<WgPeer> wgPeerRepository) {
-        this.wgPeerCreator = wgPeerCreator;
+    public WgPeerService(WgPeerGenerator peerGenerator, RepositoryPageable<WgPeer> wgPeerRepository,
+                         ISubnetSolver wgSubnetSolver, PeerCreationRules peerCreationRules) {
+        this.peerGenerator = peerGenerator;
         this.wgPeerRepository = wgPeerRepository;
+        this.wgSubnetSolver = wgSubnetSolver;
+        this.peerCreationRules = peerCreationRules;
     }
 
 
@@ -48,7 +51,11 @@ public class WgPeerService {
     }
 
     public CreatedPeer createPeerGenerateNulls(PeerCreationRequest peerCreationRequest) {
-        CreatedPeer createdPeer = wgPeerCreator.createPeerGenerateNulls(peerCreationRequest);
+        HashSet<Subnet> allowedIps = peerCreationRequest.getAllowedIps() == null ? new HashSet<>() : new HashSet<>(peerCreationRequest.getAllowedIps());
+        obtainSubnets(allowedIps);
+        allowedIps.addAll(generateSubnets(peerCreationRequest.getCountOfIpsToGenerate(), peerCreationRules.getDefaultMask()));
+        peerCreationRequest.setAllowedIps(allowedIps);
+        CreatedPeer createdPeer = peerGenerator.createPeerGenerateNulls(peerCreationRequest);
         wgPeerRepository.add(WgPeer.publicKey(createdPeer.getPublicKey())
                 .presharedKey(createdPeer.getPresharedKey())
                 .allowedIPv4Subnets(createdPeer.getAllowedSubnets())
@@ -57,36 +64,70 @@ public class WgPeerService {
         return createdPeer;
     }
 
+    private Set<Subnet> generateSubnets(int countOfIpsToGenerate, int mask) {
+        Set<Subnet> subnets = new HashSet<>();
+        for (int i = 0; i < countOfIpsToGenerate; i++) {
+            subnets.add(wgSubnetSolver.obtainFree(mask));
+        }
+        return subnets;
+    }
+
+    private void obtainSubnets(Set<Subnet> subnets) {
+        Set<Subnet> obtainedSubnets = new HashSet<>();
+        try{
+            subnets.forEach((subnet) -> {
+                wgSubnetSolver.obtain(subnet);
+                obtainedSubnets.add(subnet);
+            });
+        } catch (Exception e){
+            obtainedSubnets.forEach(wgSubnetSolver::release);
+            throw e;
+        }
+    }
 
 
     public WgPeer updatePeer(PeerUpdateRequest updateRequest) {
         WgPeer oldPeer = wgPeerRepository.getBySpecification(new FindByPublicKey(updateRequest.getCurrentPublicKey()))
                 .stream()
-                .findFirst().orElseThrow();
+                .findFirst().orElseThrow(
+                        () -> new NoSuchElementException("Peer with public key %s not found".formatted(updateRequest.getCurrentPublicKey()))
+                );
+        throwIfPeerExists(updateRequest.getNewPublicKey());
         WgPeer.Builder newPeerBuilder = WgPeer.from(oldPeer);
         newPeerBuilder.publicKey(
                 updateRequest.getNewPublicKey() != null ? updateRequest.getNewPublicKey() : oldPeer.getPublicKey());
-        consumeIfNotNullElseDefault(updateRequest.getPresharedKey(), oldPeer.getPresharedKey(), psk -> newPeerBuilder.presharedKey((String) psk));
-        consumeIfNotNullElseDefault(updateRequest.getAllowedV4Ips(), oldPeer.getAllowedSubnets().getIPv4Subnets(),
-                subnets -> newPeerBuilder.allowedIPv4Subnets((Set<Subnet>) subnets));
-        consumeIfNotNullElseDefault(updateRequest.getAllowedV6Ips(), oldPeer.getAllowedSubnets().getIPv6Subnets(),
-                subnets -> newPeerBuilder.allowedIPv6Subnets((Set<String>) subnets));
-        consumeIfNotNullElseDefault(updateRequest.getEndpoint(), oldPeer.getEndpoint(),
-                endpoint -> newPeerBuilder.endpoint((String) endpoint));
-        consumeIfNotNullElseDefault(updateRequest.getPersistentKeepalive(), oldPeer.getPersistentKeepalive(),
-                pk -> newPeerBuilder.persistentKeepalive((Integer) pk));
+        newPeerBuilder.presharedKey(defaultIfNull(updateRequest.getPresharedKey(), oldPeer.getPresharedKey()));
+        newPeerBuilder.allowedIps(defaultIfNull(updateRequest.getAllowedIps(), oldPeer.getAllowedSubnets().getAll()));
+        newPeerBuilder.endpoint(defaultIfNull(updateRequest.getEndpoint(), oldPeer.getEndpoint()));
+        newPeerBuilder.persistentKeepalive(defaultIfNull(updateRequest.getPersistentKeepalive(), oldPeer.getPersistentKeepalive()));
         WgPeer newPeer = newPeerBuilder.build();
+        obtainNewSubnets(oldPeer, newPeer);
         wgPeerRepository.update(oldPeer, newPeer);
         return newPeer;
     }
 
-    private void consumeIfNotNullElseDefault(@Nullable Object object, Object defaultVal, Consumer<Object> consumer) {
-        if (object != null) {
-            consumer.accept(object);
-        } else {
-            consumer.accept(defaultVal);
-        }
+    private void obtainNewSubnets(WgPeer oldPeer, WgPeer newPeer) {
+      /*  Set<Subnet> oldSubnets = oldPeer.getAllowedSubnets().getSubnets();
+        Set<Subnet> newSubnets = newPeer.getAllowedSubnets().getSubnets();
+        Set<Subnet> subnetsToObtain = new HashSet<>(newSubnets);
+        subnetsToObtain.removeAll(oldSubnets);
+        obtainSubnets(subnetsToObtain);*/
     }
+
+    private void throwIfPeerExists(String publicKey) {
+        wgPeerRepository.getBySpecification(new FindByPublicKey(publicKey))
+                .stream()
+                .findFirst().ifPresent(
+                        peer -> {
+                            throw new IllegalArgumentException("Peer with public key %s already exists".formatted(publicKey));
+                        }
+                );
+    }
+
+    public <T> T defaultIfNull(T value, T defaultValue) {
+        return value != null ? value : defaultValue;
+    }
+
 
 
     public CreatedPeer createPeer() {

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerService.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerService.java
@@ -1,7 +1,7 @@
 package com.wireguard.external.wireguard.peer;
 
 import com.wireguard.external.network.ISubnet;
-import com.wireguard.external.network.ISubnetSolver;
+import com.wireguard.external.network.IV4SubnetSolver;
 import com.wireguard.external.network.Subnet;
 import com.wireguard.external.shell.ShellRunner;
 import com.wireguard.external.wireguard.*;
@@ -14,27 +14,27 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.util.*;
 
 @Component
 @Scope("singleton")
+@Service
 public class WgPeerService {
 
     private static final Logger logger = LoggerFactory.getLogger(ShellRunner.class);
     WgPeerGenerator peerGenerator;
     RepositoryPageable<WgPeer> wgPeerRepository;
-    ISubnetSolver wgSubnetSolver;
-    PeerCreationRules peerCreationRules;
+    SubnetService subnetService;
 
 
     @Autowired
     public WgPeerService(WgPeerGenerator peerGenerator, RepositoryPageable<WgPeer> wgPeerRepository,
-                         ISubnetSolver wgSubnetSolver, PeerCreationRules peerCreationRules) {
+                         SubnetService subnetService) {
         this.peerGenerator = peerGenerator;
         this.wgPeerRepository = wgPeerRepository;
-        this.wgSubnetSolver = wgSubnetSolver;
-        this.peerCreationRules = peerCreationRules;
+        this.subnetService = subnetService;
     }
 
 
@@ -54,45 +54,28 @@ public class WgPeerService {
 
     public CreatedPeer createPeerGenerateNulls(PeerCreationRequest peerCreationRequest) {
         HashSet<ISubnet> allowedIps = new HashSet<>(peerCreationRequest.getAllowedIps());
-        obtainSubnets(IpUtils.filterV4Ips(allowedIps));
-        allowedIps.addAll(generateSubnets(peerCreationRequest.getCountOfIpsToGenerate(), peerCreationRules.getDefaultMask()));
+        subnetService.obtain(allowedIps);
+        allowedIps.addAll(subnetService.generateV4(peerCreationRequest.getCountOfIpsToGenerate()));
         peerCreationRequest.setAllowedIps(allowedIps);
+
         CreatedPeer createdPeer = peerGenerator.createPeerGenerateNulls(peerCreationRequest);
-        wgPeerRepository.add(WgPeer.publicKey(createdPeer.getPublicKey())
-                .presharedKey(createdPeer.getPresharedKey())
-                .allowedIps(createdPeer.getAllowedSubnets())
-                .persistentKeepalive(createdPeer.getPersistentKeepalive())
-                .build());
+        wgPeerRepository.add(createdPeerToWgPeer(createdPeer));
         return createdPeer;
     }
 
-
-    private Set<Subnet> generateSubnets(int countOfIpsToGenerate, int mask) {
-        Set<Subnet> subnets = new HashSet<>();
-        for (int i = 0; i < countOfIpsToGenerate; i++) {
-            subnets.add(wgSubnetSolver.obtainFree(mask));
-        }
-        return subnets;
+    private WgPeer createdPeerToWgPeer(CreatedPeer createdPeer) {
+        return WgPeer.publicKey(createdPeer.getPublicKey())
+                .presharedKey(createdPeer.getPresharedKey())
+                .allowedIps(createdPeer.getAllowedSubnets())
+                .persistentKeepalive(createdPeer.getPersistentKeepalive())
+                .build();
     }
 
-    private void obtainSubnets(Set<Subnet> subnets) {
-        Set<Subnet> obtainedSubnets = new HashSet<>();
-        try{
-            subnets.forEach((subnet) -> {
-                wgSubnetSolver.obtain(subnet);
-                obtainedSubnets.add(subnet);
-            });
-        } catch (Exception e){
-            obtainedSubnets.forEach(wgSubnetSolver::release);
-            throw e;
-        }
-    }
+
 
 
     public WgPeer updatePeer(PeerUpdateRequest updateRequest) {
-        WgPeer oldPeer = wgPeerRepository.getBySpecification(new FindByPublicKey(updateRequest.getCurrentPublicKey()))
-                .stream()
-                .findFirst().orElseThrow(
+        WgPeer oldPeer = getPeerByPublicKey(updateRequest.getCurrentPublicKey()).orElseThrow(
                         () -> new NoSuchElementException("Peer with public key %s not found".formatted(updateRequest.getCurrentPublicKey()))
                 );
         throwIfPeerExists(updateRequest.getNewPublicKey());
@@ -104,18 +87,11 @@ public class WgPeerService {
         newPeerBuilder.endpoint(defaultIfNull(updateRequest.getEndpoint(), oldPeer.getEndpoint()));
         newPeerBuilder.persistentKeepalive(defaultIfNull(updateRequest.getPersistentKeepalive(), oldPeer.getPersistentKeepalive()));
         WgPeer newPeer = newPeerBuilder.build();
-        obtainNewSubnets(oldPeer, newPeer);
+        subnetService.applyState(oldPeer.getAllowedSubnets().getAll(), newPeer.getAllowedSubnets().getAll());
         wgPeerRepository.update(oldPeer, newPeer);
         return newPeer;
     }
 
-    private void obtainNewSubnets(WgPeer oldPeer, WgPeer newPeer) {
-      /*  Set<Subnet> oldSubnets = oldPeer.getAllowedSubnets().getSubnets();
-        Set<Subnet> newSubnets = newPeer.getAllowedSubnets().getSubnets();
-        Set<Subnet> subnetsToObtain = new HashSet<>(newSubnets);
-        subnetsToObtain.removeAll(oldSubnets);
-        obtainSubnets(subnetsToObtain);*/
-    }
 
     private void throwIfPeerExists(String publicKey) {
         wgPeerRepository.getBySpecification(new FindByPublicKey(publicKey))

--- a/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
@@ -1,6 +1,7 @@
 package com.wireguard.external.wireguard.test;
 
 import com.wireguard.external.network.Subnet;
+import com.wireguard.external.network.SubnetV6;
 import com.wireguard.external.wireguard.WgTool;
 import com.wireguard.external.wireguard.iface.WgInterface;
 import com.wireguard.external.wireguard.peer.WgPeer;
@@ -34,7 +35,7 @@ public class FakeWgTool extends WgTool {
                         Set.of(Subnet.valueOf("10.0.0.4/32"),Subnet.valueOf("10.0.0.5/32"))).build(),
                 WgPeer.publicKey("PubKey7").presharedKey("presharedKey7").allowedIPv4Subnets(Set.of(Subnet.valueOf("10.0.0.6/32")))
                         .latestHandshake(100000).transferRx(12345).transferTx(54321).build(),
-                WgPeer.publicKey("PubKey8").presharedKey("presharedKey8").allowedIPv4Subnets(Set.of(Subnet.valueOf("10.0.0.7/32")))
+                WgPeer.publicKey("PubKey8").presharedKey("presharedKey8").allowedIps(Set.of(Subnet.valueOf("10.0.0.7/32"), SubnetV6.valueOf("::1/128")))
                         .latestHandshake(200000).transferRx(12345).transferTx(54321).build()
         ).forEach(peer -> peers.put(peer.getPublicKey(), peer));
         keyCounter = peers.size()+1;

--- a/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
@@ -1,15 +1,18 @@
 package com.wireguard.external.wireguard.test;
 
 import com.wireguard.external.network.Subnet;
-import com.wireguard.parser.WgShowDump;
 import com.wireguard.external.wireguard.WgTool;
 import com.wireguard.external.wireguard.iface.WgInterface;
 import com.wireguard.external.wireguard.peer.WgPeer;
+import com.wireguard.parser.WgShowDump;
 import lombok.SneakyThrows;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Profile("test")
 @Component

--- a/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
@@ -9,21 +9,19 @@ import lombok.SneakyThrows;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @Profile("test")
 @Component
 public class FakeWgTool extends WgTool {
-    private List<WgPeer> peers = new ArrayList<>();
+    private Map<String, WgPeer> peers = new HashMap<>();
     private WgInterface wgInterface;
     private int keyCounter;
 
     public FakeWgTool() {
         super(1);
         wgInterface = new WgInterface("privkey", "pubkey", 16666, 0);
-        peers.addAll(List.of(
+        List.of(
                 WgPeer.publicKey("pubkey1").build(),
                 WgPeer.publicKey("pubkey2").presharedKey("presharedKey2").build(),
                 WgPeer.publicKey("PubKey3").presharedKey("presharedKey3").endpoint("10.0.0.1").build(),
@@ -35,13 +33,13 @@ public class FakeWgTool extends WgTool {
                         .latestHandshake(100000).transferRx(12345).transferTx(54321).build(),
                 WgPeer.publicKey("PubKey8").presharedKey("presharedKey8").allowedIPv4Subnets(Set.of(Subnet.valueOf("10.0.0.7/32")))
                         .latestHandshake(200000).transferRx(12345).transferTx(54321).build()
-        ));
+        ).forEach(peer -> peers.put(peer.getPublicKey(), peer));
         keyCounter = peers.size()+1;
     }
     @SneakyThrows
     @Override
     public WgShowDump showDump(String interfaceName) {
-        return new WgShowDump(wgInterface, peers);
+        return new WgShowDump(wgInterface, peers.values().stream().toList());
     }
 
     @Override
@@ -50,17 +48,18 @@ public class FakeWgTool extends WgTool {
     }
 
     @Override
-    synchronized public void addPeer(String interfaceName, WgPeer peer) {
-        peers.add(WgPeer.publicKey(peer.getPublicKey())
-                .presharedKey(peer.getPresharedKey())
-                .allowedIPv4Subnets(peer.getAllowedSubnets().getIPv4Subnets())
-                .persistentKeepalive(peer.getPersistentKeepalive()).build()
-        );
+    synchronized public void addPeer(String interfaceName, WgPeer newPeer) {
+        WgPeer.Builder peerBuilder = WgPeer.from(peers.getOrDefault(newPeer.getPublicKey(), newPeer));
+        if (newPeer.getPresharedKey()!= null) peerBuilder.presharedKey(newPeer.getPresharedKey());
+        peerBuilder.allowedIPv4Subnets(newPeer.getAllowedSubnets().getIPv4Subnets());
+        if (newPeer.getEndpoint()!= null) peerBuilder.endpoint(newPeer.getEndpoint());
+        peerBuilder.persistentKeepalive(newPeer.getPersistentKeepalive());
+        peers.put(newPeer.getPublicKey(), peerBuilder.build());
     }
 
     @Override
     public void deletePeer(String interfaceName, String publicKey) {
-        peers.stream().filter(peer -> peer.getPublicKey().equals(publicKey)).findFirst().ifPresent(peers::remove);
+        peers.remove(publicKey);
     }
 
 

--- a/src/main/java/com/wireguard/parser/Utils.java
+++ b/src/main/java/com/wireguard/parser/Utils.java
@@ -2,11 +2,8 @@ package com.wireguard.parser;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Scanner;
 
 public class Utils {
-    private static final String IPV4_CIDR_REGEX = "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/([1-3][0-2]$|[0-2][0-9]$|0?[0-9]$)";
-    private static final String IPV6_REGEX = "^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$";
 
     public static ArrayList<String> trimAll(List<String> args){
         ArrayList<String> trimmedArgs = new ArrayList<>();
@@ -14,27 +11,6 @@ public class Utils {
             trimmedArgs.add(arg.trim());
         }
         return trimmedArgs;
-    }
-
-    public static boolean isIpV4Cidr(String ip){
-        return ip.matches(IPV4_CIDR_REGEX);
-    }
-
-    public static boolean isIpV6Cidr(String ip){
-        List<String> ipAndCidr = List.of(ip.split("/"));
-        if (ipAndCidr.size() != 2) return false;
-        return isIpV6(ipAndCidr.get(0)) && isCidrV6(ipAndCidr.get(1));
-    }
-
-    private static boolean isCidrV6(String s) {
-        Scanner sc = new Scanner(s);
-        if (!sc.hasNextInt()) return false;
-        int cidr = sc.nextInt();
-        return cidr >= 0 && cidr <= 128;
-    }
-
-    public static boolean isIpV6(String ip){
-        return ip.matches(IPV6_REGEX);
     }
 
 }

--- a/src/main/java/com/wireguard/parser/WgPeerParser.java
+++ b/src/main/java/com/wireguard/parser/WgPeerParser.java
@@ -1,13 +1,11 @@
 package com.wireguard.parser;
 
-import com.wireguard.external.network.Subnet;
+import com.wireguard.external.network.ISubnet;
 import com.wireguard.external.wireguard.peer.WgPeer;
 import com.wireguard.utils.IpUtils;
 import org.springframework.util.Assert;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -27,13 +25,12 @@ public class WgPeerParser {
         WgShowPeerDump = WgShowPeerDump.stream()
                 .map(s -> s.equals("(none)") ? null : s).collect(Collectors.toList());
 
-        Map<IpUtils.IpType, Set<String>> allowedIps = IpUtils.splitIpv4AndIpv6(splitToStringSet(WgShowPeerDump.get(3), ","));
+        Set<ISubnet> allowedIps = IpUtils.stringToSubnetSet(splitToStringSet(WgShowPeerDump.get(3), ","));
         return WgPeer.
                 publicKey( WgShowPeerDump.get(0))
                 .presharedKey(WgShowPeerDump.get(1))
                 .endpoint(WgShowPeerDump.get(2))
-                .allowedIPv4Subnets(allowedIps.get(IpUtils.IpType.IPV4).stream().map(Subnet::valueOf).collect(Collectors.toSet()))
-                .allowedIPv6Subnets(allowedIps.get(IpUtils.IpType.IPV6))
+                .allowedIps(allowedIps)
                 .latestHandshake(Long.parseLong(WgShowPeerDump.get(4)))
                 .transferRx(Long.parseLong(WgShowPeerDump.get(5)))
                 .transferTx(Long.parseLong(WgShowPeerDump.get(6)))

--- a/src/main/java/com/wireguard/parser/WgPeerParser.java
+++ b/src/main/java/com/wireguard/parser/WgPeerParser.java
@@ -2,6 +2,7 @@ package com.wireguard.parser;
 
 import com.wireguard.external.network.Subnet;
 import com.wireguard.external.wireguard.peer.WgPeer;
+import com.wireguard.utils.IpUtils;
 import org.springframework.util.Assert;
 
 import java.util.HashSet;
@@ -26,13 +27,13 @@ public class WgPeerParser {
         WgShowPeerDump = WgShowPeerDump.stream()
                 .map(s -> s.equals("(none)") ? null : s).collect(Collectors.toList());
 
-        Map<IpType, Set<String>> allowedIps = filterAllowedIps(WgShowPeerDump.get(3));
+        Map<IpUtils.IpType, Set<String>> allowedIps = IpUtils.splitIpv4AndIpv6(splitToStringSet(WgShowPeerDump.get(3), ","));
         return WgPeer.
                 publicKey( WgShowPeerDump.get(0))
                 .presharedKey(WgShowPeerDump.get(1))
                 .endpoint(WgShowPeerDump.get(2))
-                .allowedIPv4Subnets(allowedIps.get(IpType.IPV4).stream().map(Subnet::valueOf).collect(Collectors.toSet()))
-                .allowedIPv6Subnets(allowedIps.get(IpType.IPV6))
+                .allowedIPv4Subnets(allowedIps.get(IpUtils.IpType.IPV4).stream().map(Subnet::valueOf).collect(Collectors.toSet()))
+                .allowedIPv6Subnets(allowedIps.get(IpUtils.IpType.IPV6))
                 .latestHandshake(Long.parseLong(WgShowPeerDump.get(4)))
                 .transferRx(Long.parseLong(WgShowPeerDump.get(5)))
                 .transferTx(Long.parseLong(WgShowPeerDump.get(6)))
@@ -40,23 +41,8 @@ public class WgPeerParser {
                 .build();
     }
 
-    private enum IpType {
-        IPV4, IPV6
-    }
-    private static Map<IpType, Set<String>> filterAllowedIps(String allowedIps){
-        Map<IpType, Set<String>> allowedIpsMap = Map.of(IpType.IPV4, new HashSet<>(), IpType.IPV6, new HashSet<>());
-        if (allowedIps==null) return allowedIpsMap;
-        Set<String> allowedIpsStringsList = Set.of(allowedIps.split(","));
-        allowedIpsStringsList.forEach(allowedIp -> {
-            if (Utils.isIpV4Cidr(allowedIp)){
-                allowedIpsMap.get(IpType.IPV4).add(allowedIp);
-            } else if (Utils.isIpV6Cidr(allowedIp)){
-                allowedIpsMap.get(IpType.IPV6).add(allowedIp);
-            } else {
-                throw new IllegalArgumentException("WgPeerParser.parseAllowedIps: invalid IP address %s".formatted(allowedIp));
-            }
-        });
-        return allowedIpsMap;
+    private static Set<String> splitToStringSet(String string, String splitter){
+        return Set.of(string.split(splitter));
     }
 
     private static int parsePersistentKeepalive(String persistentKeepalive){

--- a/src/main/java/com/wireguard/parser/WgPeerParser.java
+++ b/src/main/java/com/wireguard/parser/WgPeerParser.java
@@ -42,6 +42,7 @@ public class WgPeerParser {
     }
 
     private static Set<String> splitToStringSet(String string, String splitter){
+        if (string==null) return Set.of();
         return Set.of(string.split(splitter));
     }
 

--- a/src/main/java/com/wireguard/utils/IpUtils.java
+++ b/src/main/java/com/wireguard/utils/IpUtils.java
@@ -1,8 +1,11 @@
 package com.wireguard.utils;
 
-import com.wireguard.parser.WgPeerParser;
+import com.wireguard.external.network.ISubnet;
+import com.wireguard.external.network.Subnet;
+import com.wireguard.external.network.SubnetV6;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class IpUtils {
     private static final String IPV4_CIDR_REGEX = "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/([1-3][0-2]$|[0-2][0-9]$|0?[0-9]$)";
@@ -30,19 +33,37 @@ public class IpUtils {
         return ip.matches(IPV6_REGEX);
     }
 
-    public static Map<IpType, Set<String>> splitIpv4AndIpv6(Set<String> ipsStrings){
-        Map<IpType, Set<String>> ipsMap = Map.of(IpType.IPV4, new HashSet<>(), IpType.IPV6, new HashSet<>());
+    public static Map<IpType, Set<ISubnet>> splitIpv4AndIpv6(Set<String> ipsStrings){
+        Map<IpType, Set<ISubnet>> ipsMap = Map.of(IpType.IPV4, new HashSet<>(), IpType.IPV6, new HashSet<>());
         if (ipsStrings==null) return ipsMap;
         ipsStrings.forEach(allowedIp -> {
             if (IpUtils.isIpV4Cidr(allowedIp)){
-                ipsMap.get(IpType.IPV4).add(allowedIp);
+                ipsMap.get(IpType.IPV4).add(Subnet.valueOf(allowedIp));
             } else if (IpUtils.isIpV6Cidr(allowedIp)){
-                ipsMap.get(IpType.IPV6).add(allowedIp);
+                ipsMap.get(IpType.IPV6).add(SubnetV6.valueOf(allowedIp));
             } else {
                 throw new IllegalArgumentException("WgPeerParser.parseAllowedIps: invalid IP address %s".formatted(allowedIp));
             }
         });
         return ipsMap;
+    }
+
+    public static Set<ISubnet> stringToSubnetSet(Set<String> ipsStrings){
+        Set<ISubnet> ipsSet = new HashSet<>();
+        splitIpv4AndIpv6(ipsStrings).forEach((ipType, subnets) -> ipsSet.addAll(subnets));
+        return ipsSet;
+    }
+
+    public static Set<Subnet> filterV4Ips(Set<ISubnet> ips){
+        return ips.stream().filter(ip -> ip instanceof Subnet)
+                .map(ip -> (Subnet) ip)
+                .collect(Collectors.toSet());
+    }
+
+    public static Set<SubnetV6> filterV6Ips(Set<ISubnet> ips){
+        return ips.stream().filter(ip -> ip instanceof SubnetV6)
+                .map(ip -> (SubnetV6) ip)
+                .collect(Collectors.toSet());
     }
 
     public enum IpType {

--- a/src/main/java/com/wireguard/utils/IpUtils.java
+++ b/src/main/java/com/wireguard/utils/IpUtils.java
@@ -39,11 +39,15 @@ public class IpUtils {
         ipsStrings.forEach(allowedIp -> {
             if (IpUtils.isIpV4Cidr(allowedIp)){
                 ipsMap.get(IpType.IPV4).add(Subnet.valueOf(allowedIp));
-            } else if (IpUtils.isIpV6Cidr(allowedIp)){
-                ipsMap.get(IpType.IPV6).add(SubnetV6.valueOf(allowedIp));
             } else {
-                throw new IllegalArgumentException("WgPeerParser.parseAllowedIps: invalid IP address %s".formatted(allowedIp));
+                try{
+                    ipsMap.get(IpType.IPV6).add(SubnetV6.valueOf(allowedIp));
+                } catch (IllegalArgumentException e){
+                    throw new IllegalArgumentException("WgPeerParser.parseAllowedIps: Invalid IP address %s. %s".formatted(
+                            allowedIp, e.getMessage()));
+                }
             }
+
         });
         return ipsMap;
     }

--- a/src/main/java/com/wireguard/utils/IpUtils.java
+++ b/src/main/java/com/wireguard/utils/IpUtils.java
@@ -1,0 +1,52 @@
+package com.wireguard.utils;
+
+import com.wireguard.parser.WgPeerParser;
+
+import java.util.*;
+
+public class IpUtils {
+    private static final String IPV4_CIDR_REGEX = "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/([1-3][0-2]$|[0-2][0-9]$|0?[0-9]$)";
+    private static final String IPV6_REGEX = "^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$";
+
+    public static boolean isIpV4Cidr(String ip){
+        return ip.matches(IPV4_CIDR_REGEX);
+    }
+
+    public static boolean isIpV6Cidr(String ip){
+        List<String> ipAndCidr = List.of(ip.split("/"));
+        if (ipAndCidr.size() != 2) return false;
+        return isIpV6(ipAndCidr.get(0)) && isCidrV6(ipAndCidr.get(1));
+    }
+
+
+    private static boolean isCidrV6(String s) {
+        Scanner sc = new Scanner(s);
+        if (!sc.hasNextInt()) return false;
+        int cidr = sc.nextInt();
+        return cidr >= 0 && cidr <= 128;
+    }
+
+    public static boolean isIpV6(String ip){
+        return ip.matches(IPV6_REGEX);
+    }
+
+    public static Map<IpType, Set<String>> splitIpv4AndIpv6(Set<String> ipsStrings){
+        Map<IpType, Set<String>> ipsMap = Map.of(IpType.IPV4, new HashSet<>(), IpType.IPV6, new HashSet<>());
+        if (ipsStrings==null) return ipsMap;
+        ipsStrings.forEach(allowedIp -> {
+            if (IpUtils.isIpV4Cidr(allowedIp)){
+                ipsMap.get(IpType.IPV4).add(allowedIp);
+            } else if (IpUtils.isIpV6Cidr(allowedIp)){
+                ipsMap.get(IpType.IPV6).add(allowedIp);
+            } else {
+                throw new IllegalArgumentException("WgPeerParser.parseAllowedIps: invalid IP address %s".formatted(allowedIp));
+            }
+        });
+        return ipsMap;
+    }
+
+    public enum IpType {
+        IPV4, IPV6
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,5 @@ wg.config.save.min-interval=2000
 logging.api.max-elements=1000
 springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.path=/swagger-ui
-logging.file.path=logs
 wg.cache.enabled=true
 wg.cache.update-interval=60

--- a/src/test/java/com/wireguard/api/inteface/InterfaceControllerTest.java
+++ b/src/test/java/com/wireguard/api/inteface/InterfaceControllerTest.java
@@ -2,7 +2,6 @@ package com.wireguard.api.inteface;
 
 import com.wireguard.external.wireguard.iface.WgInterface;
 import com.wireguard.external.wireguard.iface.WgInterfaceService;
-import com.wireguard.external.wireguard.peer.WgPeerService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/wireguard/api/peer/PeerControllerTest.java
+++ b/src/test/java/com/wireguard/api/peer/PeerControllerTest.java
@@ -203,8 +203,8 @@ class PeerControllerTest {
                         .build())
                 .exchange()
                 .expectStatus().isCreated()
-                .expectBody(CreatedPeer.class)
-                .isEqualTo(newPeer);
+                .expectBody(CreatedPeerDTO.class)
+                .isEqualTo(CreatedPeerDTO.from(newPeer));
     }
 
     @Test

--- a/src/test/java/com/wireguard/api/peer/PeerControllerTest.java
+++ b/src/test/java/com/wireguard/api/peer/PeerControllerTest.java
@@ -4,7 +4,7 @@ import com.wireguard.api.AppError;
 import com.wireguard.api.dto.PageDTO;
 import com.wireguard.external.network.NoFreeIpException;
 import com.wireguard.external.network.Subnet;
-import com.wireguard.external.wireguard.EmptyPeerCreationRequest;
+import com.wireguard.external.network.SubnetV6;
 import com.wireguard.external.wireguard.Paging;
 import com.wireguard.external.wireguard.ParsingException;
 import com.wireguard.external.wireguard.PeerCreationRequest;
@@ -14,13 +14,18 @@ import com.wireguard.external.wireguard.peer.WgPeerService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.support.PagedListHolder;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -37,7 +42,7 @@ class PeerControllerTest {
             WgPeer.publicKey("PubKey2")
                     .presharedKey("PresharedKey2")
                     .allowedIPv4Subnets(Set.of(Subnet.valueOf("10.0.0.1/32"),Subnet.valueOf("10.1.1.1/30")))
-                    .allowedIPv6Subnets(Set.of("2001:db8::/32"))
+                    .allowedIPv6Subnets(Set.of(SubnetV6.valueOf("2001:db8::/32")))
                     .transferTx(100)
                     .transferRx(200)
                     .latestHandshake(300)

--- a/src/test/java/com/wireguard/external/wireguard/PagingTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/PagingTest.java
@@ -1,8 +1,6 @@
 package com.wireguard.external.wireguard;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/src/test/java/com/wireguard/external/wireguard/SubnetTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/SubnetTest.java
@@ -3,6 +3,8 @@ package com.wireguard.external.wireguard;
 import com.wireguard.external.network.Subnet;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigInteger;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -24,7 +26,7 @@ class SubnetTest {
         Subnet subnet = Subnet.valueOf("192.168.0.3/24");
         assertEquals("192.168.0.255", subnet.getLastIpString(), ".getLastIpString()");
         assertEquals("192.168.0.0", subnet.getFirstIpString(), ".getFirstIpString()");
-        assertEquals(256, subnet.getIpCount(), ".getIpCount()");
+        assertEquals(BigInteger.valueOf(256), subnet.getIpCount(), ".getIpCount()");
         assertEquals(24, subnet.getNumericMask(), ".getNumericMask()");
         assertEquals(3232235775L, subnet.getLastIpNumeric(), ".getLastIpNumeric()");
         assertEquals(3232235520L, subnet.getFirstIpNumeric(), ".getFirstIpNumeric()");
@@ -35,7 +37,7 @@ class SubnetTest {
         Subnet subnet = Subnet.valueOf("0.0.0.0/0");
         assertEquals("0.0.0.0", subnet.getFirstIpString(), ".getFirstIpString()");
         assertEquals("255.255.255.255", subnet.getLastIpString(), ".getLastIpString()");
-        assertEquals(4294967296L, subnet.getIpCount(), ".getIpCount()");
+        assertEquals(BigInteger.valueOf(4294967296L), subnet.getIpCount(), ".getIpCount()");
         assertEquals(0, subnet.getNumericMask(), ".getNumericMask()");
         assertEquals(0L, subnet.getFirstIpNumeric(), ".getFirstIpNumeric()");
         assertEquals(4294967295L, subnet.getLastIpNumeric(), ".getLastIpNumeric()");

--- a/src/test/java/com/wireguard/external/wireguard/SubnetTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/SubnetTest.java
@@ -3,8 +3,6 @@ package com.wireguard.external.wireguard;
 import com.wireguard.external.network.Subnet;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -74,24 +72,7 @@ class SubnetTest {
         assertEquals(32767L, subnet.getLastIpNumeric(), ".getLastIpNumeric()");
     }
 
-    @Test
-    public void getIpTest() {
-        Subnet subnet = Subnet.valueOf("192.168.0.2/17");
-        assertEquals(List.of(192,168,0,2), subnet.getIp(), ".getIp()");
-    }
 
-    @Test
-    public void getFirstIpTest() {
-        Subnet subnet = Subnet.valueOf("192.168.0.5/20");
-        assertEquals(List.of(192,168,0,0), subnet.getFirstIp(), ".getFirstIp()");
-    }
-
-    @Test
-    public void getLastIpTest() {
-        Subnet subnet = Subnet.valueOf("192.168.0.5/20");
-        assertEquals(List.of(192, 168, 15, 255), subnet.getLastIp(), ".getLastIp()");
-
-    }
 
 
 }

--- a/src/test/java/com/wireguard/external/wireguard/WgPeerServiceTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/WgPeerServiceTest.java
@@ -1,5 +1,6 @@
 package com.wireguard.external.wireguard;
 
+import com.wireguard.external.network.ISubnet;
 import com.wireguard.external.network.Subnet;
 import com.wireguard.external.network.SubnetSolver;
 import com.wireguard.external.wireguard.peer.*;
@@ -85,7 +86,7 @@ class WgPeerServiceTest {
     public void testCreatePeerGenerateNulls() {
         CreatedPeer shouldBeReturned = new CreatedPeer("publicKey", "Psk", "Ppk", Set.of(Subnet.valueOf("10.66.66.1/32")), 0);
         PeerCreationRequest peerCreationRequest = new PeerCreationRequest("publicKey", "Psk", "Ppk",
-                Mockito.any(), 0, 1);
+                Set.of(), 0, 1);
         Mockito.when(wgPeerGenerator.createPeerGenerateNulls(
                         peerCreationRequest))
                 .thenReturn(shouldBeReturned);

--- a/src/test/java/com/wireguard/external/wireguard/WgPeerServiceTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/WgPeerServiceTest.java
@@ -21,16 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class WgPeerServiceTest {
     private WgPeerService wgPeerService;
 
-    WgPeerGenerator wgPeerGenerator;
-    WgPeerRepository wgPeerRepository;
-    SubnetSolver subnetSolver;
+    WgPeerRepository wgPeerRepository = Mockito.mock(WgPeerRepository.class);
+    WgPeerGenerator wgPeerGenerator = Mockito.mock(WgPeerGenerator.class);
+    SubnetService subnetService = Mockito.mock(SubnetService.class);
 
     @BeforeEach
     public void setup() {
-        wgPeerRepository = Mockito.mock(WgPeerRepository.class);
-        wgPeerGenerator = Mockito.mock(WgPeerGenerator.class);
-        subnetSolver = Mockito.mock(SubnetSolver.class);
-        wgPeerService = new WgPeerService(wgPeerGenerator, wgPeerRepository, subnetSolver,new PeerCreationRules(32));
+        wgPeerService = new WgPeerService(wgPeerGenerator, wgPeerRepository, subnetService);
     }
 
     @Test
@@ -93,6 +90,7 @@ class WgPeerServiceTest {
         CreatedPeer createdPeer = wgPeerService.createPeerGenerateNulls(peerCreationRequest);
         Assertions.assertNotNull(createdPeer);
         Assertions.assertEquals(shouldBeReturned, createdPeer);
+        Mockito.verify(subnetService, Mockito.times(1)).generateV4(Mockito.anyInt());
         Mockito.verify(wgPeerGenerator, Mockito.times(1)).createPeerGenerateNulls(
                 new PeerCreationRequest(shouldBeReturned.getPublicKey(), shouldBeReturned.getPresharedKey(), shouldBeReturned.getPrivateKey(),
                 Mockito.any(), shouldBeReturned.getPersistentKeepalive(), 1));
@@ -106,6 +104,7 @@ class WgPeerServiceTest {
         wgPeerService.createPeer();
         Mockito.verify(wgPeerGenerator, Mockito.times(1)).createPeerGenerateNulls(
                 new EmptyPeerCreationRequest());
+        Mockito.verify(subnetService, Mockito.times(1)).generateV4(Mockito.anyInt());
         Mockito.verify(wgPeerRepository, Mockito.times(1)).add(Mockito.any(WgPeer.class));
     }
 
@@ -113,5 +112,6 @@ class WgPeerServiceTest {
     public void deletePeer(){
         wgPeerService.deletePeer("publicKey");
         Mockito.verify(wgPeerRepository, Mockito.times(1)).remove(Mockito.any());
+        Mockito.verify(subnetService, Mockito.times(1)).release(Mockito.any());
     }
 }

--- a/src/test/java/com/wireguard/external/wireguard/WgPeerServiceTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/WgPeerServiceTest.java
@@ -110,6 +110,8 @@ class WgPeerServiceTest {
 
     @Test
     public void deletePeer(){
+        Mockito.when(wgPeerRepository.getBySpecification(new FindByPublicKey("publicKey")))
+                .thenReturn(List.of(WgPeer.publicKey("publicKey").build()));
         wgPeerService.deletePeer("publicKey");
         Mockito.verify(wgPeerRepository, Mockito.times(1)).remove(Mockito.any());
         Mockito.verify(subnetService, Mockito.times(1)).release(Mockito.any());

--- a/src/test/java/com/wireguard/external/wireguard/peer/WgPeerGeneratorTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/peer/WgPeerGeneratorTest.java
@@ -1,6 +1,6 @@
 package com.wireguard.external.wireguard.peer;
 
-import com.wireguard.external.network.ISubnetSolver;
+import com.wireguard.external.network.IV4SubnetSolver;
 import com.wireguard.external.network.Subnet;
 import com.wireguard.external.wireguard.EmptyPeerCreationRequest;
 import com.wireguard.external.wireguard.PeerCreationRequest;
@@ -14,13 +14,13 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class WgPeerGeneratorTest {
-    ISubnetSolver subnetSolver;
+    IV4SubnetSolver subnetSolver;
     WgTool wgTool;
     WgPeerGenerator wgPeerGenerator;
 
     @BeforeEach
     public void setup() {
-        subnetSolver = Mockito.mock(ISubnetSolver.class);
+        subnetSolver = Mockito.mock(IV4SubnetSolver.class);
         Mockito.when(subnetSolver.obtainFree(Mockito.anyInt())).thenReturn(Subnet.valueOf("0.0.0.0/32"));
 
         wgTool = Mockito.mock(WgTool.class);

--- a/src/test/java/com/wireguard/external/wireguard/peer/WgPeerGeneratorTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/peer/WgPeerGeneratorTest.java
@@ -5,20 +5,18 @@ import com.wireguard.external.network.Subnet;
 import com.wireguard.external.wireguard.EmptyPeerCreationRequest;
 import com.wireguard.external.wireguard.PeerCreationRequest;
 import com.wireguard.external.wireguard.WgTool;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class WgPeerCreatorTest {
+class WgPeerGeneratorTest {
     ISubnetSolver subnetSolver;
     WgTool wgTool;
-    WgPeerCreator wgPeerCreator;
+    WgPeerGenerator wgPeerGenerator;
 
     @BeforeEach
     public void setup() {
@@ -27,13 +25,13 @@ class WgPeerCreatorTest {
 
         wgTool = Mockito.mock(WgTool.class);
         Mockito.when(wgTool.generatePublicKey(Mockito.any())).thenReturn("publicKey");
-        wgPeerCreator = new WgPeerCreator(wgTool,subnetSolver);
+        wgPeerGenerator = new WgPeerGenerator(wgTool);
     }
 
     @Test
     public void testCreatePeerWithNulls(){
-         CreatedPeer peer = wgPeerCreator.createPeerGenerateNulls(new EmptyPeerCreationRequest());
-            assertEquals(wgPeerCreator.DEFAULT_PERSISTENT_KEEPALIVE, peer.getPersistentKeepalive());
+         CreatedPeer peer = wgPeerGenerator.createPeerGenerateNulls(new EmptyPeerCreationRequest());
+            assertEquals(wgPeerGenerator.DEFAULT_PERSISTENT_KEEPALIVE, peer.getPersistentKeepalive());
             Mockito.verify(wgTool, Mockito.times(1)).generatePublicKey(Mockito.any());
             Mockito.verify(subnetSolver, Mockito.times(0)).obtainFree(Mockito.anyInt());
             Mockito.verify(wgTool, Mockito.times(1)).generatePrivateKey();
@@ -42,7 +40,7 @@ class WgPeerCreatorTest {
 
     @Test
     public void testCreatePeerWithData(){
-        CreatedPeer peer = wgPeerCreator.createPeerGenerateNulls(new PeerCreationRequest("publicKey","presharedKey",
+        CreatedPeer peer = wgPeerGenerator.createPeerGenerateNulls(new PeerCreationRequest("publicKey","presharedKey",
                 "privateKey", Set.of(Subnet.valueOf("0.0.0.1/32")),1, 0));
         assertEquals(1, peer.getPersistentKeepalive());
         assertEquals("publicKey", peer.getPublicKey());
@@ -50,20 +48,8 @@ class WgPeerCreatorTest {
         assertEquals("privateKey", peer.getPrivateKey());
         assertEquals(Set.of(Subnet.valueOf("0.0.0.1/32")), peer.getAllowedSubnets());
         Mockito.verify(wgTool, Mockito.times(0)).generatePublicKey(Mockito.any());
-        Mockito.verify(subnetSolver, Mockito.times(0)).obtainFree(Mockito.anyInt());
         Mockito.verify(wgTool, Mockito.times(0)).generatePrivateKey();
         Mockito.verify(wgTool, Mockito.times(0)).generatePresharedKey();
-        Mockito.verify(subnetSolver, Mockito.times(1)).obtain(Subnet.valueOf("0.0.0.1/32"));
-    }
-
-    @Test
-    public void testCreatePeerWithExceptionSubnetSolver(){
-        Mockito.doThrow(new RuntimeException()).when(subnetSolver).obtain(Mockito.any());
-        Set<Subnet> ips = Set.of(Subnet.valueOf("10.0.0.1/32"), Subnet.valueOf("10.0.0.2/32"));
-        Assertions.assertThrows(RuntimeException.class, () -> {
-            wgPeerCreator.createPeerGenerateNulls(new PeerCreationRequest(null,null,
-                    null,ips,null, 0));
-        });
     }
 
 }

--- a/src/test/java/com/wireguard/parser/IpUtilsTests.java
+++ b/src/test/java/com/wireguard/parser/IpUtilsTests.java
@@ -1,6 +1,5 @@
 package com.wireguard.parser;
 
-import com.wireguard.utils.IpUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/src/test/java/com/wireguard/parser/IpUtilsTests.java
+++ b/src/test/java/com/wireguard/parser/IpUtilsTests.java
@@ -1,0 +1,25 @@
+package com.wireguard.parser;
+
+import com.wireguard.utils.IpUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IpUtilsTests {
+
+    @Test
+    void trimAll() {
+        List<String> notTrimmed = List.of("\thello ", " wo rl\td", "test ");
+        List<String> trimmed = Utils.trimAll(notTrimmed);
+        assertEquals(notTrimmed.get(0).trim(), trimmed.get(0));
+        assertEquals(notTrimmed.get(1).trim(), trimmed.get(1));
+        assertEquals(notTrimmed.get(2).trim(), trimmed.get(2));
+    }
+
+
+
+
+
+}

--- a/src/test/java/com/wireguard/parser/WgShowDumpParserTest.java
+++ b/src/test/java/com/wireguard/parser/WgShowDumpParserTest.java
@@ -43,7 +43,7 @@ class WgShowDumpParserTest {
         Assertions.assertEquals(11, dump.peers().size());
         WgPeer peer = dump.peers().stream().filter(p -> p.getPublicKey().equals("8avysqyA1N+IIX8d1gergergergergbHf2TfuEfw4ff=")).findFirst().get();
         Assertions.assertEquals(FIRST_PEER_ENDPOINT, peer.getEndpoint());
-        Assertions.assertEquals(Set.of("10.66.66.2/32", "fd42:42:42::2/128"), peer.getAllowedSubnets().getAll());
+        Assertions.assertEquals(Set.of("10.66.66.2/32", "fd42:42:42::2/128"), peer.getAllowedSubnets().getAllStrings());
         Assertions.assertEquals(FIRST_PEER_PERSISTENT_KEEPALIVE, peer.getPersistentKeepalive());
         Assertions.assertEquals(FIRST_PEER_LAST_HANDSHAKE_TIME, peer.getLatestHandshake());
 


### PR DESCRIPTION
Whats new 
Now you can add IPv6 adress when creating a peer via /peer/create. Warning: at the moment WireRest only controls duplicate ips with ipv4, ipv6 is not controlled in any way. In the future, the ability to control the distribution of ipv6 addresses will be added, as it is implemented with ipv4 now.