### PR TITLE
Endpoint for update peer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,7 @@ pipeline {
         RUN_ARGS="--spring.profiles.active=${RUN_PROFILES} " +
         "--server.port=${RUN_PORT} " +
         "--wg.interface.name=server " +
-        "--debug " +
-        "--logging.level.root=DEBUG "
+        "--debug "
     }
     stages {
         stage('Build') {

--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,24 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>compile</scope>
             <version>1.18.26</version>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,15 +66,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>3.1.0</version>
             <scope>test</scope>

--- a/src/main/java/com/wireguard/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/wireguard/api/GlobalExceptionHandler.java
@@ -6,9 +6,11 @@ import com.wireguard.external.shell.CommandExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.server.ServerWebInputException;
 
 @ControllerAdvice
@@ -17,48 +19,49 @@ public class GlobalExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<AppError> catchResourceNotFoundException(ResourceNotFoundException e) {
         logger.error(e.getMessage(), e);
-        return new ResponseEntity<>(new AppError(HttpStatus.NOT_FOUND.value(), e.getMessage()), HttpStatus.NOT_FOUND);
+        return getAppErrorResponseEntity(HttpStatus.NOT_FOUND, e);
     }
 
     @ExceptionHandler
     public ResponseEntity<AppError> catchException(Exception e) {
         logger.error(e.getMessage(), e);
-        return new ResponseEntity<>(
-                new AppError(HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                        e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+        return getAppErrorResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, e);
     }
 
 
     @ExceptionHandler
-
     public ResponseEntity<AppError> badRequestException(BadRequestException e) {
         logger.error(e.getMessage(), e);
-        return new ResponseEntity<>(
-                new AppError(HttpStatus.BAD_REQUEST.value(),
-                        e.getMessage()), HttpStatus.BAD_REQUEST);
+        return getAppErrorResponseEntity(HttpStatus.BAD_REQUEST, e);
     }
 
     @ExceptionHandler
     public ResponseEntity<AppError> serverWebInputException(ServerWebInputException e) {
-        logger.warn("ServerWebInputException: ".formatted(e.getCause().getMessage()));
+        logger.warn("ServerWebInputException: %s".formatted(e.getCause().getMessage()));
+        return getAppErrorResponseEntity(e.getStatusCode(), e.getCause());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<AppError> webExchangeBindException(WebExchangeBindException e) {
+        logger.warn("Input validation error: %s".formatted(e.getMessage()));
+        return getAppErrorResponseEntity(HttpStatus.BAD_REQUEST, e);
+    }
+
+    private ResponseEntity<AppError> getAppErrorResponseEntity(HttpStatusCode statusCode, Throwable cause) {
         return new ResponseEntity<>(
-                new AppError(e.getStatusCode().value(),
-                        e.getCause().getMessage()), e.getStatusCode());
+                new AppError(statusCode.value(),
+                        cause.getMessage()), statusCode);
     }
 
     @ExceptionHandler
     public ResponseEntity<AppError> alreadyUsed(AlreadyUsedException e) {
         logger.error(e.getMessage(), e);
-        return new ResponseEntity<>(
-                new AppError(HttpStatus.BAD_REQUEST.value(),
-                        e.getMessage()), HttpStatus.BAD_REQUEST);
+        return getAppErrorResponseEntity(HttpStatus.BAD_REQUEST, e);
     }
 
     @ExceptionHandler
     public ResponseEntity<AppError> commandExecutionException(CommandExecutionException e) {
         logger.error(e.getMessage(), e);
-        return new ResponseEntity<>(
-                new AppError(HttpStatus.BAD_REQUEST.value(),
-                        "Wireguard error: %s".formatted(e.getStderr().strip())), HttpStatus.BAD_REQUEST);
+        return getAppErrorResponseEntity(HttpStatus.BAD_REQUEST, e);
     }
 }

--- a/src/main/java/com/wireguard/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/wireguard/api/GlobalExceptionHandler.java
@@ -5,13 +5,17 @@ import com.wireguard.external.network.AlreadyUsedException;
 import com.wireguard.external.shell.CommandExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.support.WebExchangeBindException;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebInputException;
+
+import java.util.NoSuchElementException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -28,6 +32,24 @@ public class GlobalExceptionHandler {
         return getAppErrorResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, e);
     }
 
+    @ExceptionHandler
+    public ResponseEntity<AppError> catchNoSuchElementException(NoSuchElementException e) {
+        logger.error(e.getMessage(), e);
+        return getAppErrorResponseEntity(HttpStatus.NOT_FOUND, e);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<AppError> catchIllegalArgumentException(IllegalArgumentException e) {
+        logger.error(e.getMessage(), e);
+        return getAppErrorResponseEntity(HttpStatus.BAD_REQUEST, e);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<AppError> catchResponseStatusException(ResponseStatusException e) {
+        logger.info(e.getMessage());
+        return getAppErrorResponseEntity(e.getStatusCode(), e);
+    }
+
 
     @ExceptionHandler
     public ResponseEntity<AppError> badRequestException(BadRequestException e) {
@@ -42,8 +64,18 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
+    public ResponseEntity<AppError> TypeMismatchException(TypeMismatchException e) {
+        return getAppErrorResponseEntity(HttpStatus.BAD_REQUEST, e);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<AppError> CommandExecutionException(CommandExecutionException e) {
+        return getAppErrorResponseEntity(HttpStatus.BAD_REQUEST, e);
+    }
+
+    @ExceptionHandler
     public ResponseEntity<AppError> webExchangeBindException(WebExchangeBindException e) {
-        logger.warn("Input validation error: %s".formatted(e.getMessage()));
+        logger.warn("Wireguard Error: %s".formatted(e.getMessage()));
         return getAppErrorResponseEntity(HttpStatus.BAD_REQUEST, e);
     }
 

--- a/src/main/java/com/wireguard/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/wireguard/api/GlobalExceptionHandler.java
@@ -69,11 +69,6 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
-    public ResponseEntity<AppError> CommandExecutionException(CommandExecutionException e) {
-        return getAppErrorResponseEntity(HttpStatus.BAD_REQUEST, e);
-    }
-
-    @ExceptionHandler
     public ResponseEntity<AppError> webExchangeBindException(WebExchangeBindException e) {
         logger.warn("Wireguard Error: %s".formatted(e.getMessage()));
         return getAppErrorResponseEntity(HttpStatus.BAD_REQUEST, e);

--- a/src/main/java/com/wireguard/api/OpenAPIServerConfig.java
+++ b/src/main/java/com/wireguard/api/OpenAPIServerConfig.java
@@ -7,9 +7,9 @@ import io.swagger.v3.oas.annotations.info.Info;
 @OpenAPIDefinition(
 
         info = @Info(
-                title = "Wireguard API",
+                title = "WireRest",
                 description = "Docs for Wireguard API",
-                version = "0.3",
+                version = "1",
                 contact = @Contact(
                         name = "FokiDoki",
                         url = "https://github.com/FokiDoki/"

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -90,11 +90,13 @@ public class PeerController {
             , allowEmptyValue = true)
     @Parameter(name = "presharedKey", description = "Preshared key or empty if no psk required (Empty if not provided)",
             allowEmptyValue = true)
+    @Parameter(name = "endpoint", description = "Endpoint IP:port ",
+            allowEmptyValue = true)
     @Parameter(name = "allowedIps", description = "New ips of the peer (Exists will be replaced)  Example: 10.0.0.11/32",
             array = @ArraySchema(arraySchema = @Schema(implementation = String.class), uniqueItems=true), allowEmptyValue = true)
     @Parameter(name = "persistentKeepalive", description = "New persistent keepalive interval in seconds (0 if not provided)", schema = @Schema(implementation = Integer.class, defaultValue = "0", example = "0", minimum = "0", maximum = "65535"))
     @Parameter(name = "peerUpdateRequestDTO", hidden = true)
-    @RequestMapping(value = "/peer/update", method = RequestMethod.PATCH) 
+    @RequestMapping(value = "/peer/update", method = RequestMethod.PATCH)
     public WgPeerDTO updatePeer(
         @Valid PeerUpdateRequestDTO peerUpdateRequestDTO
     ){

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -29,7 +29,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @RestController

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -66,7 +66,7 @@ public class PeerController {
             "Direction is optional and may have value DESC (High to low) and ASC (Low to high). Using with a large number of the peers (3000 or more) affects performance. ", example = "allowedSubnets.desc")
     public PageDTO<WgPeerDTO> getPeers(
             @RequestParam(value = "page", required = false, defaultValue = "0") int page,
-            @RequestParam(value = "limit", required = false, defaultValue = "1000") int limit,
+            @RequestParam(value = "limit", required = false, defaultValue = "100") int limit,
             @RequestParam(value = "sort", required = false) String sortKey
     ) throws ParsingException {
         Page<WgPeer> peers;
@@ -122,7 +122,7 @@ public class PeerController {
 
     private PageDTO<WgPeerDTO> pagePeerToPageDTOPeerDTO(Page<WgPeer> peers){
         List<WgPeerDTO> peerDTOs = peers.getContent().stream().map(WgPeerDTO::from).collect(Collectors.toList());
-        return new PageDTO<>(peers.getTotalPages()-1, peers.getNumber(), peerDTOs);
+        return new PageDTO<>(peers.getTotalPages(), peers.getNumber(), peerDTOs);
     }
 
 

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -86,8 +86,7 @@ public class PeerController {
     @Operation(summary = "Update peer by public key", description = "Update peer by public key. " +
             "Do not provide fields that you do not want to change.")
     @Parameter(name = "publicKey", description = "Current public key of the peer", required = true)
-    @Parameter(name = "newPublicKey", description = "New public key of the peer. Warning: If you change the public key, latest handshake and transfer data will be lost. "
-            , allowEmptyValue = true)
+    @Parameter(name = "newPublicKey", description = "New public key of the peer. Warning: If you change the public key, latest handshake and transfer data will be lost. ")
     @Parameter(name = "presharedKey", description = "Preshared key or empty if no psk required (Empty if not provided)",
             allowEmptyValue = true)
     @Parameter(name = "endpoint", description = "Endpoint IP:port ",

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -100,13 +100,9 @@ public class PeerController {
     public WgPeerDTO updatePeer(
         @Valid PeerUpdateRequestDTO peerUpdateRequestDTO
     ){
-        try {
-            WgPeer wgPeer = wgPeerService.updatePeer(
-                    peerUpdateRequestDTOToPeerUpdateRequest(peerUpdateRequestDTO));
-            return WgPeerDTO.from(wgPeer);
-        } catch (IllegalArgumentException | NoSuchElementException e) {
-            throw new BadRequestException(e.getMessage());
-        }
+        WgPeer wgPeer = wgPeerService.updatePeer(
+                peerUpdateRequestDTOToPeerUpdateRequest(peerUpdateRequestDTO));
+        return WgPeerDTO.from(wgPeer);
     }
 
     private PeerUpdateRequest peerUpdateRequestDTOToPeerUpdateRequest(PeerUpdateRequestDTO peerUpdateRequestDTO){
@@ -114,7 +110,7 @@ public class PeerController {
         if (peerUpdateRequestDTO.getAllowedIps()!=null){
             allowedIps = Optional.of(IpUtils.stringToSubnetSet(peerUpdateRequestDTO.getAllowedIps()));
         }
-        PeerUpdateRequest peerUpdateRequest = new PeerUpdateRequest(
+        return new PeerUpdateRequest(
                 peerUpdateRequestDTO.getPublicKey(),
                 peerUpdateRequestDTO.getNewPublicKey(),
                 peerUpdateRequestDTO.getPresharedKey(),
@@ -122,7 +118,6 @@ public class PeerController {
                 peerUpdateRequestDTO.getEndpoint(),
                 peerUpdateRequestDTO.getPersistentKeepalive()
         );
-        return peerUpdateRequest;
     }
 
     private PageDTO<WgPeerDTO> pagePeerToPageDTOPeerDTO(Page<WgPeer> peers){

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -93,9 +94,9 @@ public class PeerController {
             array = @ArraySchema(arraySchema = @Schema(implementation = String.class), uniqueItems=true), allowEmptyValue = true)
     @Parameter(name = "persistentKeepalive", description = "New persistent keepalive interval in seconds (0 if not provided)", schema = @Schema(implementation = Integer.class, defaultValue = "0", example = "0", minimum = "0", maximum = "65535"))
     @Parameter(name = "peerUpdateRequestDTO", hidden = true)
-    @RequestMapping(value = "/peer/update", method = RequestMethod.PATCH)
+    @RequestMapping(value = "/peer/update", method = RequestMethod.PATCH) 
     public WgPeerDTO updatePeer(
-        PeerUpdateRequestDTO peerUpdateRequestDTO
+        @Valid PeerUpdateRequestDTO peerUpdateRequestDTO
     ){
         try {
             WgPeer wgPeer = wgPeerService.updatePeer(

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -99,8 +99,6 @@ public class PeerController {
         PeerUpdateRequestDTO peerUpdateRequestDTO
     ){
         try {
-            System.out.println(peerUpdateRequestDTO);
-            System.out.println(peerUpdateRequestDTOToPeerUpdateRequest(peerUpdateRequestDTO));
             WgPeer wgPeer = wgPeerService.updatePeer(
                     peerUpdateRequestDTOToPeerUpdateRequest(peerUpdateRequestDTO));
             return WgPeerDTO.from(wgPeer);
@@ -110,17 +108,15 @@ public class PeerController {
     }
 
     private PeerUpdateRequest peerUpdateRequestDTOToPeerUpdateRequest(PeerUpdateRequestDTO peerUpdateRequestDTO){
-        Set<ISubnet> allowedIps = new HashSet<>();
+        Optional<Set<ISubnet>> allowedIps = Optional.empty();
         if (peerUpdateRequestDTO.getAllowedIps()!=null){
-            Map<IpUtils.IpType, Set<ISubnet>> allowedIpsSorted = IpUtils.splitIpv4AndIpv6(peerUpdateRequestDTO.getAllowedIps());
-            allowedIps.addAll(allowedIpsSorted.get(IpUtils.IpType.IPV4));
-            allowedIps.addAll(allowedIpsSorted.get(IpUtils.IpType.IPV6));
+            allowedIps = Optional.of(IpUtils.stringToSubnetSet(peerUpdateRequestDTO.getAllowedIps()));
         }
         PeerUpdateRequest peerUpdateRequest = new PeerUpdateRequest(
                 peerUpdateRequestDTO.getCurrentPublicKey(),
                 peerUpdateRequestDTO.getNewPublicKey(),
                 peerUpdateRequestDTO.getPresharedKey(),
-                allowedIps,
+                allowedIps.orElse(null),
                 peerUpdateRequestDTO.getEndpoint(),
                 peerUpdateRequestDTO.getPersistentKeepalive()
         );

--- a/src/main/java/com/wireguard/api/peer/PeerController.java
+++ b/src/main/java/com/wireguard/api/peer/PeerController.java
@@ -5,7 +5,6 @@ import com.wireguard.api.BadRequestException;
 import com.wireguard.api.ResourceNotFoundException;
 import com.wireguard.api.dto.PageDTO;
 import com.wireguard.external.network.ISubnet;
-import com.wireguard.external.network.Subnet;
 import com.wireguard.external.shell.CommandExecutionException;
 import com.wireguard.external.wireguard.ParsingException;
 import com.wireguard.external.wireguard.PeerCreationRequest;
@@ -63,7 +62,7 @@ public class PeerController {
     @Parameter(name = "page", description = "Page number")
     @Parameter(name = "limit", description = "Page size (In case of 0, all peers will be returned)")
     @Parameter(name = "sort", description = "Sort key and direction separated by a dot. The keys are the same as in the answer. " +
-            "Direction is optional and may have value DESC (High to low) and ASC (Low to high). Using with a large number of peers (3000 or more) affects performance. ", example = "allowedSubnets.desc")
+            "Direction is optional and may have value DESC (High to low) and ASC (Low to high). Using with a large number of the peers (3000 or more) affects performance. ", example = "allowedSubnets.desc")
     public PageDTO<WgPeerDTO> getPeers(
             @RequestParam(value = "page", required = false, defaultValue = "0") int page,
             @RequestParam(value = "limit", required = false, defaultValue = "1000") int limit,
@@ -85,12 +84,12 @@ public class PeerController {
 
     @Operation(summary = "Update peer by public key", description = "Update peer by public key. " +
             "Do not provide fields that you do not want to change.")
-    @Parameter(name = "currentPublicKey", description = "Public key of peer", required = true)
-    @Parameter(name = "newPublicKey", description = "New public key of peer. Warning: If you change the public key, latest handshake and transfer data will be lost. "
+    @Parameter(name = "publicKey", description = "Current public key of the peer", required = true)
+    @Parameter(name = "newPublicKey", description = "New public key of the peer. Warning: If you change the public key, latest handshake and transfer data will be lost. "
             , allowEmptyValue = true)
     @Parameter(name = "presharedKey", description = "Preshared key or empty if no psk required (Empty if not provided)",
             allowEmptyValue = true)
-    @Parameter(name = "allowedIps", description = "New ips of peer (Exists will be replaced)  Example: 10.0.0.11/32",
+    @Parameter(name = "allowedIps", description = "New ips of the peer (Exists will be replaced)  Example: 10.0.0.11/32",
             array = @ArraySchema(arraySchema = @Schema(implementation = String.class), uniqueItems=true), allowEmptyValue = true)
     @Parameter(name = "persistentKeepalive", description = "New persistent keepalive interval in seconds (0 if not provided)", schema = @Schema(implementation = Integer.class, defaultValue = "0", example = "0", minimum = "0", maximum = "65535"))
     @Parameter(name = "peerUpdateRequestDTO", hidden = true)
@@ -113,7 +112,7 @@ public class PeerController {
             allowedIps = Optional.of(IpUtils.stringToSubnetSet(peerUpdateRequestDTO.getAllowedIps()));
         }
         PeerUpdateRequest peerUpdateRequest = new PeerUpdateRequest(
-                peerUpdateRequestDTO.getCurrentPublicKey(),
+                peerUpdateRequestDTO.getPublicKey(),
                 peerUpdateRequestDTO.getNewPublicKey(),
                 peerUpdateRequestDTO.getPresharedKey(),
                 allowedIps.orElse(null),

--- a/src/main/java/com/wireguard/api/peer/PeerCreationRequestDTO.java
+++ b/src/main/java/com/wireguard/api/peer/PeerCreationRequestDTO.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.util.HashSet;
 import java.util.Set;
 
 @AllArgsConstructor

--- a/src/main/java/com/wireguard/api/peer/PeerUpdateRequestDTO.java
+++ b/src/main/java/com/wireguard/api/peer/PeerUpdateRequestDTO.java
@@ -1,6 +1,5 @@
 package com.wireguard.api.peer;
 
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/wireguard/api/peer/PeerUpdateRequestDTO.java
+++ b/src/main/java/com/wireguard/api/peer/PeerUpdateRequestDTO.java
@@ -1,5 +1,7 @@
 package com.wireguard.api.peer;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -8,6 +10,7 @@ import java.util.Set;
 @Data
 @AllArgsConstructor
 public class PeerUpdateRequestDTO {
+    @NotNull
     private final String publicKey;
     private final String newPublicKey;
     private final String presharedKey;

--- a/src/main/java/com/wireguard/api/peer/PeerUpdateRequestDTO.java
+++ b/src/main/java/com/wireguard/api/peer/PeerUpdateRequestDTO.java
@@ -8,7 +8,7 @@ import java.util.Set;
 @Data
 @AllArgsConstructor
 public class PeerUpdateRequestDTO {
-    private final String currentPublicKey;
+    private final String publicKey;
     private final String newPublicKey;
     private final String presharedKey;
     private final Set<String> allowedIps;

--- a/src/main/java/com/wireguard/external/network/IV4SubnetSolver.java
+++ b/src/main/java/com/wireguard/external/network/IV4SubnetSolver.java
@@ -24,6 +24,19 @@ public interface IV4SubnetSolver extends ISubnetSolver{
         public long getIpsCount(){
             return biggest - least + 1;
         }
+        private String toIpString(long ip){
+            return String.format("%d.%d.%d.%d",
+                    (ip >> 24) & 0xff,
+                    (ip >> 16) & 0xff,
+                    (ip >> 8) & 0xff,
+                    ip & 0xff);
+        }
+        public String getLeastString(){
+            return toIpString(least);
+        }
+        public String getBiggestString(){
+            return toIpString(biggest);
+        }
     }
 
 }

--- a/src/main/java/com/wireguard/external/network/QueuedSubnetSolver.java
+++ b/src/main/java/com/wireguard/external/network/QueuedSubnetSolver.java
@@ -1,12 +1,13 @@
 package com.wireguard.external.network;
 
-
 import lombok.SneakyThrows;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
+import static com.wireguard.utils.AsyncUtils.await;
 
 public class QueuedSubnetSolver implements IV4SubnetSolver {
 
@@ -52,14 +53,7 @@ public class QueuedSubnetSolver implements IV4SubnetSolver {
         return isUsedFuture.get();
     }
 
-    @SneakyThrows
-    private void await(Future<?> future){
-        try {
-            future.get();
-        } catch (ExecutionException e) {
-            throw e.getCause();
-        }
-    }
+
 
     @Override
     public long getAvailableIpsCount() {

--- a/src/main/java/com/wireguard/external/network/SubnetSolver.java
+++ b/src/main/java/com/wireguard/external/network/SubnetSolver.java
@@ -75,7 +75,8 @@ public class SubnetSolver implements IV4SubnetSolver {
         long firstAddress = subnet.getFirstIpNumeric();
         long lastAddress = subnet.getLastIpNumeric();
         if (!isIpsInRange(firstAddress, lastAddress, totalAvailableRange)){
-            throw new IllegalArgumentException("Subnet " + subnet + " is not in allowed ips range +"+ totalAvailableRange);
+            throw new IllegalArgumentException("Subnet %s is not in allowed ips range %s - %s"
+                    .formatted(subnet, totalAvailableRange.getLeastString(), totalAvailableRange.getBiggestString()));
         }
         if (getAvailableIpsCount()==0L){
             throw new NoFreeIpException("No free ip left in "+ totalAvailableRange);

--- a/src/main/java/com/wireguard/external/shell/StreamToStringConverter.java
+++ b/src/main/java/com/wireguard/external/shell/StreamToStringConverter.java
@@ -14,7 +14,7 @@ public class StreamToStringConverter implements Converter<InputStream, String> {
 
     private Charset charset = StandardCharsets.UTF_8;
 
-    private static final Logger logger = LoggerFactory.getLogger(ShellRunner.class);
+    private static final Logger logger = LoggerFactory.getLogger(StreamToStringConverter.class);
 
     public StreamToStringConverter(Charset charset) {
         this.charset = charset;

--- a/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
+++ b/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
@@ -1,9 +1,9 @@
 package com.wireguard.external.wireguard;
 
-import org.aspectj.weaver.ast.Call;
-import org.springframework.scheduling.concurrent.ThreadPoolExecutorFactoryBean;
-
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.*;
 
 public class BlockingByHashAsyncExecutor<T> {

--- a/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
+++ b/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
@@ -22,12 +22,8 @@ public class BlockingByHashAsyncExecutor<T> {
             T taskResult = null;
             synchronized (queue) {
                 Callable<T> tCallable = queue.poll();
-                try {
-                    assert tCallable != null;
-                    taskResult = tCallable.call();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+                assert tCallable != null;
+                taskResult = tCallable.call();
                 synchronized (tasks) {
                     if (queue.isEmpty()) {
                         tasks.remove(hash);

--- a/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
+++ b/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
@@ -7,25 +7,34 @@ import java.util.*;
 import java.util.concurrent.*;
 
 public class BlockingByHashAsyncExecutor<T> {
-    final Map<String, Queue<Callable<T>>> tasks = Collections.synchronizedMap(new LinkedHashMap<>());
+    private final Map<String, Queue<Callable<T>>> tasks = Collections.synchronizedMap(new LinkedHashMap<>());
 
     private final ExecutorService executor = Executors.newCachedThreadPool();
-    
+
     public Future<T> addTask(String hash, Callable<T> task) {
         synchronized (tasks) {
             Queue<Callable<T>> queue = tasks.computeIfAbsent(hash, k -> new LinkedBlockingQueue<>());
             queue.add(task);
         }
+
         return executor.submit(() -> {
             Queue<Callable<T>> queue = tasks.get(hash);
+            T taskResult = null;
             synchronized (queue) {
-                Callable<T> poll = queue.poll();
-                if (poll == null) {
+                Callable<T> tCallable = queue.poll();
+                try {
+                    assert tCallable != null;
+                    taskResult = tCallable.call();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            synchronized (tasks) {
+                if (queue.isEmpty()) {
                     tasks.remove(hash);
-                    return null;
                 }
-                return poll.call();
-                }
+            }
+            return taskResult;
 
         });
     }

--- a/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
+++ b/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
@@ -1,2 +1,35 @@
-package com.wireguard.external.wireguard;public class BlockingByHashAsyncExecutor {
+package com.wireguard.external.wireguard;
+
+import org.aspectj.weaver.ast.Call;
+import org.springframework.scheduling.concurrent.ThreadPoolExecutorFactoryBean;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public class BlockingByHashAsyncExecutor<T> {
+    final Map<String, Queue<Callable<T>>> tasks = Collections.synchronizedMap(new LinkedHashMap<>());
+
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    
+    public Future<T> addTask(String hash, Callable<T> task) {
+        synchronized (tasks) {
+            Queue<Callable<T>> queue = tasks.computeIfAbsent(hash, k -> new LinkedBlockingQueue<>());
+            queue.add(task);
+        }
+        return executor.submit(() -> {
+            Queue<Callable<T>> queue = tasks.get(hash);
+            synchronized (queue) {
+                Callable<T> poll = queue.poll();
+                if (poll == null) {
+                    tasks.remove(hash);
+                    return null;
+                }
+                return poll.call();
+                }
+
+        });
+    }
+
+
+
 }

--- a/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
+++ b/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
@@ -28,12 +28,13 @@ public class BlockingByHashAsyncExecutor<T> {
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
-            }
-            synchronized (tasks) {
-                if (queue.isEmpty()) {
-                    tasks.remove(hash);
+                synchronized (tasks) {
+                    if (queue.isEmpty()) {
+                        tasks.remove(hash);
+                    }
                 }
             }
+
             return taskResult;
 
         });

--- a/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
+++ b/src/main/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutor.java
@@ -1,0 +1,2 @@
+package com.wireguard.external.wireguard;public class BlockingByHashAsyncExecutor {
+}

--- a/src/main/java/com/wireguard/external/wireguard/Paging.java
+++ b/src/main/java/com/wireguard/external/wireguard/Paging.java
@@ -70,7 +70,7 @@ public class Paging<T> {
         PagedListHolder<T> page = new PagedListHolder<>(sorted);
         page.setPageSize(pageable.getPageSize());
         if (pageable.getPageNumber() >= page.getPageCount()) {
-            throw new PageOutOfRangeException(pageable.getPageNumber(), page.getPageCount()-1);
+            throw new PageOutOfRangeException(pageable.getPageNumber(), page.getPageCount());
         }
         page.setPage(pageable.getPageNumber());
         return new PageImpl<T>(new ArrayList<>(page.getPageList()), pageable, list.size());

--- a/src/main/java/com/wireguard/external/wireguard/PeerCreationRequest.java
+++ b/src/main/java/com/wireguard/external/wireguard/PeerCreationRequest.java
@@ -1,7 +1,6 @@
 package com.wireguard.external.wireguard;
 
 import com.wireguard.external.network.ISubnet;
-import com.wireguard.external.network.Subnet;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/com/wireguard/external/wireguard/SubnetService.java
+++ b/src/main/java/com/wireguard/external/wireguard/SubnetService.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 @Component
 public class SubnetService {
 
-    private static final Logger logger = LoggerFactory.getLogger(WgPeerService.class);
+    private static final Logger logger = LoggerFactory.getLogger(SubnetService.class);
     PeerCreationRules peerCreationRules;
     IV4SubnetSolver v4SubnetSolver;
 
@@ -42,6 +42,7 @@ public class SubnetService {
                 subnets.add(v4SubnetSolver.obtainFree(mask));
             }
         });
+        logger.debug("Generated subnets: {}", subnets);
         return Collections.unmodifiableSet(subnets);
     }
 
@@ -57,6 +58,7 @@ public class SubnetService {
         try{
             consumer.accept(subnets);
         } catch (Exception e){
+            logger.debug("Exception occurred during obtaining subnets, releasing subnets: {}", subnets);
             release(subnets);
             throw e;
         }
@@ -64,6 +66,7 @@ public class SubnetService {
 
     public void release(Set<? extends ISubnet> subnets) {
         subnets.forEach((subnet) -> {
+            logger.debug("Releasing subnet: {}", subnet);
             if (subnet instanceof Subnet) {
                 v4SubnetSolver.release((Subnet) subnet);
             } else if (subnet instanceof SubnetV6) {
@@ -75,6 +78,7 @@ public class SubnetService {
     public void obtain(Set<? extends ISubnet> subnets) {
         Set<ISubnet> obtainedSubnets = new HashSet<>();
         releaseIfException(obtainedSubnets, (s) -> {
+            logger.debug("Obtaining subnets: {}", subnets);
             subnets.forEach((subnet) -> {
                 if (subnet instanceof Subnet){
                     v4SubnetSolver.obtain((Subnet) subnet);
@@ -93,6 +97,7 @@ public class SubnetService {
         Set<ISubnet> subnetsToObtain = new HashSet<>(newState);
         subnetsToObtain.removeAll(oldState);
         obtain(subnetsToObtain);
+        logger.debug("Applied subnet state, old state: {}, new state: {}", oldState, newState);
     }
 
 

--- a/src/main/java/com/wireguard/external/wireguard/SubnetService.java
+++ b/src/main/java/com/wireguard/external/wireguard/SubnetService.java
@@ -4,10 +4,7 @@ import com.wireguard.external.network.ISubnet;
 import com.wireguard.external.network.IV4SubnetSolver;
 import com.wireguard.external.network.Subnet;
 import com.wireguard.external.network.SubnetV6;
-import com.wireguard.external.shell.StreamToStringConverter;
 import com.wireguard.external.wireguard.peer.PeerCreationRules;
-import com.wireguard.external.wireguard.peer.WgPeer;
-import com.wireguard.external.wireguard.peer.WgPeerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,10 +13,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 
 @Service
 @Component

--- a/src/main/java/com/wireguard/external/wireguard/SubnetService.java
+++ b/src/main/java/com/wireguard/external/wireguard/SubnetService.java
@@ -7,6 +7,9 @@ import com.wireguard.external.network.SubnetV6;
 import com.wireguard.external.shell.StreamToStringConverter;
 import com.wireguard.external.wireguard.peer.PeerCreationRules;
 import com.wireguard.external.wireguard.peer.WgPeer;
+import com.wireguard.external.wireguard.peer.WgPeerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
@@ -22,6 +25,7 @@ import java.util.stream.Stream;
 @Component
 public class SubnetService {
 
+    private static final Logger logger = LoggerFactory.getLogger(WgPeerService.class);
     PeerCreationRules peerCreationRules;
     IV4SubnetSolver v4SubnetSolver;
 

--- a/src/main/java/com/wireguard/external/wireguard/SubnetService.java
+++ b/src/main/java/com/wireguard/external/wireguard/SubnetService.java
@@ -50,6 +50,8 @@ public class SubnetService {
         return generateV4(countOfIpsToGenerate, peerCreationRules.getDefaultMask());
     }
 
+
+
     public Set<SubnetV6> generateV6(int countOfIpsToGenerate, int mask) {
         throw new UnsupportedOperationException("It doesn't support yet");
     }

--- a/src/main/java/com/wireguard/external/wireguard/WgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/WgTool.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 @Profile("prod")
 @Component
 public class WgTool {
-    private static final Logger logger = LoggerFactory.getLogger(ShellRunner.class);
+    private static final Logger logger = LoggerFactory.getLogger(WgTool.class);
 
     private static final String WG_SHOW_DUMP_COMMAND = "wg show %s dump";
     private static final String WG_GENKEY_COMMAND = "wg genkey";

--- a/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
@@ -14,13 +14,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 @Component
 @ConditionalOnProperty(value = "wg.cache.enabled", havingValue = "true")

--- a/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/CachedWgPeerRepository.java
@@ -92,8 +92,8 @@ public class CachedWgPeerRepository extends WgPeerRepository implements Reposito
                     .filter(subnet -> !subnetSolver.isUsed(subnet))
                     .forEach(subnetSolver::obtain);
         }
-        wgPeers.removeAll(cachedPeers);
-        wgPeers.forEach(wgPeer -> wgPeerCache.invalidate(wgPeer.getPublicKey()));
+        cachedPeers.removeAll(wgPeers);
+        cachedPeers.forEach(wgPeer -> wgPeerCache.invalidate(wgPeer.getPublicKey()));
     }
 
     @Override

--- a/src/main/java/com/wireguard/external/wireguard/peer/CreatedPeer.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/CreatedPeer.java
@@ -1,7 +1,6 @@
 package com.wireguard.external.wireguard.peer;
 
 import com.wireguard.external.network.ISubnet;
-import com.wireguard.external.network.Subnet;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeer.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeer.java
@@ -133,6 +133,7 @@ public class WgPeer implements Comparable<WgPeer> {
         }
 
         public Builder allowedIps(Set<ISubnet> allowedSubnets) {
+            this.allowedSubnets = new AllowedSubnets();
             allowedSubnets.forEach(
                     subnet -> {
                         if(subnet instanceof Subnet){

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeer.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeer.java
@@ -8,7 +8,6 @@ import org.springframework.util.Assert;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeer.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeer.java
@@ -8,11 +8,13 @@ import org.springframework.util.Assert;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(of = "publicKey")
 public class WgPeer implements Comparable<WgPeer> {
     private final String publicKey;
     private String presharedKey;
@@ -42,7 +44,7 @@ public class WgPeer implements Comparable<WgPeer> {
                 ", persistentKeepalive=" + persistentKeepalive +
                 '}';
     }
-
+    
     @Override
     public int compareTo(WgPeer o) {
         return this.publicKey.compareTo(o.publicKey);

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerGenerator.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerGenerator.java
@@ -1,7 +1,6 @@
 package com.wireguard.external.wireguard.peer;
 
 import com.wireguard.external.network.ISubnet;
-import com.wireguard.external.network.Subnet;
 import com.wireguard.external.wireguard.PeerCreationRequest;
 import com.wireguard.external.wireguard.WgTool;
 import org.slf4j.Logger;

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerRepository.java
@@ -54,13 +54,18 @@ public class WgPeerRepository implements RepositoryPageable<WgPeer> {
 
     @Override
     public List<WgPeer> getByAllSpecifications(List<Specification<WgPeer>> specifications) {
-        return getAll().stream()
+        return getByAllSpecifications(specifications, getAll());
+    }
+
+    protected List<WgPeer> getByAllSpecifications(List<Specification<WgPeer>> specifications, List<WgPeer> peers) {
+        return peers.stream()
                 .filter(wgPeer ->
                         specifications.stream().allMatch(
                                 specification -> specification.isExist(wgPeer)
                         )
-                        ).collect(Collectors.toList());
+                ).collect(Collectors.toList());
     }
+
 
     @Override
     public List<WgPeer> getAll() {

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerService.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerService.java
@@ -1,12 +1,8 @@
 package com.wireguard.external.wireguard.peer;
 
 import com.wireguard.external.network.ISubnet;
-import com.wireguard.external.network.IV4SubnetSolver;
-import com.wireguard.external.network.Subnet;
-import com.wireguard.external.shell.ShellRunner;
 import com.wireguard.external.wireguard.*;
 import com.wireguard.external.wireguard.peer.spec.FindByPublicKey;
-import com.wireguard.utils.IpUtils;
 import lombok.SneakyThrows;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,8 +13,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-import java.util.concurrent.Callable;
+import java.util.HashSet;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.concurrent.Future;
 
 import static com.wireguard.utils.AsyncUtils.await;

--- a/src/main/java/com/wireguard/external/wireguard/peer/WgPeerService.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/WgPeerService.java
@@ -23,7 +23,7 @@ import java.util.*;
 @Service
 public class WgPeerService {
 
-    private static final Logger logger = LoggerFactory.getLogger(ShellRunner.class);
+    private static final Logger logger = LoggerFactory.getLogger(WgPeerService.class);
     WgPeerGenerator peerGenerator;
     RepositoryPageable<WgPeer> wgPeerRepository;
     SubnetService subnetService;
@@ -78,11 +78,15 @@ public class WgPeerService {
     }
 
 
+    private boolean isUpdateRequestHasNewPublicKey(PeerUpdateRequest updateRequest) {
+        return updateRequest.getNewPublicKey() != null &&
+                updateRequest.getNewPublicKey().equals(updateRequest.getCurrentPublicKey());
+    }
 
 
     public WgPeer updatePeer(PeerUpdateRequest updateRequest) {
         WgPeer oldPeer = getPeerByPublicKeyOrThrow(updateRequest.getCurrentPublicKey());
-        throwIfPeerExists(updateRequest.getNewPublicKey());
+        if (isUpdateRequestHasNewPublicKey(updateRequest)) throwIfPeerExists(updateRequest.getNewPublicKey());
         WgPeer.Builder newPeerBuilder = WgPeer.from(oldPeer);
         newPeerBuilder.publicKey(
                 updateRequest.getNewPublicKey() != null ? updateRequest.getNewPublicKey() : oldPeer.getPublicKey());
@@ -110,7 +114,6 @@ public class WgPeerService {
     public <T> T defaultIfNull(T value, T defaultValue) {
         return value != null ? value : defaultValue;
     }
-
 
 
     public CreatedPeer createPeer() {

--- a/src/main/java/com/wireguard/external/wireguard/peer/spec/FindByPublicKey.java
+++ b/src/main/java/com/wireguard/external/wireguard/peer/spec/FindByPublicKey.java
@@ -3,10 +3,12 @@ package com.wireguard.external.wireguard.peer.spec;
 import com.wireguard.external.wireguard.Specification;
 import com.wireguard.external.wireguard.peer.WgPeer;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 @EqualsAndHashCode
 public class FindByPublicKey implements Specification<WgPeer> {
 
+    @Getter
     private final String publicKey;
 
     public FindByPublicKey(String publicKey) {

--- a/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
@@ -35,18 +35,11 @@ public class FakeWgTool extends WgTool {
                 WgPeer.publicKey("PubKey8").presharedKey("presharedKey8").allowedIps(Set.of(Subnet.valueOf("10.0.0.7/32"), SubnetV6.valueOf("::1/128")))
                         .latestHandshake(200000).transferRx(12345).transferTx(54321).build()
         ).forEach(peer -> peers.put(peer.getPublicKey(), peer));
-        /*
-        for (keyCounter = 9; keyCounter < 25000; keyCounter++) {
-
-            peers.put("PubKey"+keyCounter, WgPeer.publicKey("PubKey"+keyCounter).presharedKey("presharedKey"+keyCounter).build());
-
-        }*/
         keyCounter = peers.size()+1;
     }
     @SneakyThrows
     @Override
     public WgShowDump showDump(String interfaceName) {
-        System.out.println(peers.remove("PubKey"+ new Random().nextInt(keyCounter)));
         return new WgShowDump(wgInterface, peers.values().stream().toList());
     }
 

--- a/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
@@ -10,10 +10,7 @@ import lombok.SneakyThrows;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 @Profile("test")
 @Component
@@ -38,11 +35,18 @@ public class FakeWgTool extends WgTool {
                 WgPeer.publicKey("PubKey8").presharedKey("presharedKey8").allowedIps(Set.of(Subnet.valueOf("10.0.0.7/32"), SubnetV6.valueOf("::1/128")))
                         .latestHandshake(200000).transferRx(12345).transferTx(54321).build()
         ).forEach(peer -> peers.put(peer.getPublicKey(), peer));
+        /*
+        for (keyCounter = 9; keyCounter < 25000; keyCounter++) {
+
+            peers.put("PubKey"+keyCounter, WgPeer.publicKey("PubKey"+keyCounter).presharedKey("presharedKey"+keyCounter).build());
+
+        }*/
         keyCounter = peers.size()+1;
     }
     @SneakyThrows
     @Override
     public WgShowDump showDump(String interfaceName) {
+        System.out.println(peers.remove("PubKey"+ new Random().nextInt(keyCounter)));
         return new WgShowDump(wgInterface, peers.values().stream().toList());
     }
 

--- a/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
+++ b/src/main/java/com/wireguard/external/wireguard/test/FakeWgTool.java
@@ -26,8 +26,8 @@ public class FakeWgTool extends WgTool {
         super(1);
         wgInterface = new WgInterface("privkey", "pubkey", 16666, 0);
         List.of(
-                WgPeer.publicKey("pubkey1").build(),
-                WgPeer.publicKey("pubkey2").presharedKey("presharedKey2").build(),
+                WgPeer.publicKey("PubKey1").build(),
+                WgPeer.publicKey("PubKey2").presharedKey("presharedKey2").build(),
                 WgPeer.publicKey("PubKey3").presharedKey("presharedKey3").endpoint("10.0.0.1").build(),
                 WgPeer.publicKey("PubKey4").presharedKey("presharedKey4").allowedIPv4Subnets(Set.of(Subnet.valueOf("10.0.0.2/32"))).build(),
                 WgPeer.publicKey("PubKey5").presharedKey("presharedKey5").allowedIPv4Subnets(Set.of(Subnet.valueOf("10.0.0.3/32"))).build(),
@@ -51,6 +51,7 @@ public class FakeWgTool extends WgTool {
         return "PrivateKey"+keyCounter++;
     }
 
+    @SneakyThrows
     @Override
     synchronized public void addPeer(String interfaceName, WgPeer newPeer) {
         WgPeer.Builder peerBuilder = WgPeer.from(peers.getOrDefault(newPeer.getPublicKey(), newPeer));

--- a/src/main/java/com/wireguard/parser/WgShowDumpParser.java
+++ b/src/main/java/com/wireguard/parser/WgShowDumpParser.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Scanner;
 
@@ -39,7 +40,7 @@ public class WgShowDumpParser {
 
 
     private static List<WgPeer> parsePeers(Scanner peersDump) {
-        List<WgPeer> peers = new ArrayList<>();
+        List<WgPeer> peers = new LinkedList<>();
         while (peersDump.hasNextLine()) {
             String line = peersDump.nextLine();
             logger.trace("Parsing peer "+line);

--- a/src/main/java/com/wireguard/parser/WgShowDumpParser.java
+++ b/src/main/java/com/wireguard/parser/WgShowDumpParser.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Scanner;

--- a/src/main/java/com/wireguard/utils/AsyncUtils.java
+++ b/src/main/java/com/wireguard/utils/AsyncUtils.java
@@ -1,0 +1,18 @@
+package com.wireguard.utils;
+
+import lombok.SneakyThrows;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+public class AsyncUtils {
+
+    @SneakyThrows
+    public static <T> T await(Future<T> future){
+        try {
+            return future.get();
+        } catch (ExecutionException e) {
+            throw e.getCause();
+        }
+    }
+}

--- a/src/test/java/com/wireguard/api/peer/PeerControllerTest.java
+++ b/src/test/java/com/wireguard/api/peer/PeerControllerTest.java
@@ -245,4 +245,5 @@ class PeerControllerTest {
     }
 
 
+
 }

--- a/src/test/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutorTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutorTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BlockingByHashAsyncExecutorTest {
 

--- a/src/test/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutorTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/BlockingByHashAsyncExecutorTest.java
@@ -1,0 +1,91 @@
+package com.wireguard.external.wireguard;
+
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BlockingByHashAsyncExecutorTest {
+
+    BlockingByHashAsyncExecutor<Map<String, Long>> blockingByHashAsyncExecutor = new BlockingByHashAsyncExecutor<>();
+    private static final int sleepTimeMs = 10;
+
+
+    static class Task {
+        final long uuid = new Random().nextLong();
+        @SneakyThrows
+        public Map<String, Long> call() {
+            Thread.sleep(sleepTimeMs);
+            return Map.of("uuid",uuid, "time",System.currentTimeMillis());
+        }
+    }
+
+    private List<Task> generateTasks(int count){
+        List<Task> tasks = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            tasks.add(new Task());
+        }
+        return tasks;
+
+    }
+
+    private List<Future<Map<String, Long>>> generateAndRunTasks(String hash, int count){
+        List<Future<Map<String, Long>>> futures = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            Task task = new Task();
+            futures.add(blockingByHashAsyncExecutor.addTask(hash, task::call));
+        }
+        return futures;
+    }
+
+    @Test
+    void testTaskIsExecutedInRightTime() {
+        List<Future<Map<String, Long>>> futures = generateAndRunTasks("hash", 2);
+        List<Map<String, Long>> res = waitAll(futures);
+        assertTrue(Math.abs(res.get(0).get("time") - res.get(1).get("time"))>sleepTimeMs-1);
+    }
+
+    @Test
+    void testTaskIsExecutedParallel() {
+        List<Future<Map<String, Long>>> futures = generateAndRunTasks("hash", 1);
+        List<Future<Map<String, Long>>> futures2 = generateAndRunTasks("hash2", 1);
+        List<Map<String, Long>> res = waitAll(futures);
+        res.add(waitAll(futures2).get(0));
+        assertTrue(Math.abs(res.get(0).get("time") - res.get(1).get("time"))<sleepTimeMs-1);
+    }
+
+    @Test
+    void isQueueFlushWhenNoTasksLeft(){
+        List<Future<Map<String, Long>>> futures = generateAndRunTasks("hash", 1);
+        waitAll(futures);
+        Map<String, Queue<Callable<Task>>> queue = getQueue();
+        assertTrue(queue.isEmpty());
+    }
+
+    @SneakyThrows
+    private Map<String, Queue<Callable<Task>>> getQueue() {
+        Field field = Arrays.stream(BlockingByHashAsyncExecutor.class.getDeclaredFields())
+                        .filter(f -> f.getName().equals("tasks")).findFirst().orElseThrow();
+        field.setAccessible(true);
+        return (Map<String, Queue<Callable<Task>>>) field.get(blockingByHashAsyncExecutor);
+    }
+
+    private List<Map<String, Long>> waitAll(List<Future<Map<String, Long>>> futures) {
+        List<Map<String, Long>> results = new ArrayList<>();
+        futures.forEach(future -> {
+            try {
+                results.add(future.get(sleepTimeMs*3, TimeUnit.MILLISECONDS));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return results;
+    }
+
+}

--- a/src/test/java/com/wireguard/external/wireguard/SubnetServiceTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/SubnetServiceTest.java
@@ -1,0 +1,183 @@
+package com.wireguard.external.wireguard;
+
+import com.wireguard.external.network.ISubnet;
+import com.wireguard.external.network.IV4SubnetSolver;
+import com.wireguard.external.network.Subnet;
+import com.wireguard.external.network.SubnetSolver;
+import com.wireguard.external.wireguard.peer.PeerCreationRules;
+import com.wireguard.external.wireguard.peer.WgPeer;
+import lombok.ToString;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class SubnetServiceTest {
+
+    PeerCreationRules peerCreationRules = Mockito.mock(PeerCreationRules.class);
+    IV4SubnetSolver subnetSolver = Mockito.mock(IV4SubnetSolver.class);
+    private final SubnetService subnetService = new SubnetService(peerCreationRules, subnetSolver);
+
+    public SubnetServiceTest(){
+        Mockito.when(subnetSolver.obtainFree(Mockito.anyInt())).then((Answer<Subnet>) invocation -> getRandomSubnetMock());
+        Mockito.when(peerCreationRules.getDefaultMask()).thenReturn(32);
+    }
+
+    private ISubnet getRandomISubnetMock(){
+        return Mockito.mock(ISubnet.class);
+
+    }
+
+    private Set<ISubnet> generateRandomISubnets(int count){
+        Set<ISubnet> subnets = new HashSet<>();
+        for (int i = 0; i < count; i++) {
+            subnets.add(getRandomISubnetMock());
+        }
+        return subnets;
+    }
+
+    private Set<Subnet> generateRandomSubnets(int count){
+        Set<Subnet> subnets = new HashSet<>();
+        for (int i = 0; i < count; i++) {
+            subnets.add(getRandomSubnetMock());
+        }
+        return subnets;
+    }
+    private Subnet getRandomSubnetMock(){
+        return Mockito.mock(Subnet.class);
+    }
+
+    @BeforeAll
+    static void setUp(){
+
+    }
+    void generateV4(int mask, int count) {
+        Set<Subnet> generatedSubnets = subnetService.generateV4(count, mask);
+        Mockito.verify(subnetSolver, Mockito.times(count)).obtainFree(mask);
+        Assertions.assertNotNull(generatedSubnets);
+        Assertions.assertEquals(generatedSubnets.size(), count);
+    }
+    @Test
+    void generateV4Test(){
+        generateV4(30, 10);
+    }
+
+    @Test
+    void generateV4Count0() {
+        generateV4(30, 0);
+    }
+
+    @Test
+    void generateV4OneArgument() {
+        subnetService.generateV4(10);
+        Mockito.verify(peerCreationRules, Mockito.times(1)).getDefaultMask();
+    }
+    @Test
+    void generateV6() {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> subnetService.generateV6(32,1));
+    }
+
+    void release(Set<? extends ISubnet> subnets) {
+        subnetService.release(subnets);
+        Mockito.verify(subnetSolver, Mockito.times(subnets.size())).release(Mockito.any(Subnet.class));
+    }
+
+    @Test
+    void releaseTest(){
+        release(generateRandomSubnets(10));
+    }
+
+    @Test
+    void releaseTestCount0(){
+        release(generateRandomSubnets(0));
+    }
+
+    @Test
+    void releaseTestNull(){
+        Assertions.assertThrows(NullPointerException.class, () -> release(null));
+    }
+
+    void obtain(Set<? extends ISubnet> subnets) {
+        subnetService.obtain(subnets);
+        Mockito.verify(subnetSolver, Mockito.times(subnets.size())).obtain(Mockito.any(Subnet.class));
+    }
+
+    @Test
+    void obtainTest(){
+        obtain(generateRandomSubnets(10));
+    }
+
+    @Test
+    void obtainTestCount0(){
+        obtain(generateRandomSubnets(0));
+    }
+
+    @Test
+    void obtainTestNull(){
+        Assertions.assertThrows(NullPointerException.class, () -> obtain(null));
+    }
+
+    @Test
+    void obtainException(){
+        Mockito.doNothing()
+                .doThrow(new RuntimeException())
+                .when(subnetSolver).obtain(Mockito.any(Subnet.class));
+        Assertions.assertThrows(RuntimeException.class, () -> obtain(generateRandomSubnets(2)));
+        Mockito.verify(subnetSolver, Mockito.times(1)).release(Mockito.any(Subnet.class));
+
+    }
+
+    void applyState(Set<? extends ISubnet> before, Set<? extends ISubnet> after) {
+        subnetService.applyState(before, after);
+        Set<? extends ISubnet> subnetsToRelease = before.stream().filter(i -> !after.contains(i)).collect(Collectors.toSet());
+        Set<? extends ISubnet> subnetsToObtain = after.stream().filter(i -> !before.contains(i)).collect(Collectors.toSet());
+        Mockito.verify(subnetSolver, Mockito.times(subnetsToRelease.size())).release(Mockito.any(Subnet.class));
+        Mockito.verify(subnetSolver, Mockito.times(subnetsToObtain.size())).obtain(Mockito.any(Subnet.class));
+
+    }
+
+    @Test
+    void testApplyState(){
+        applyState(generateRandomSubnets(10), generateRandomSubnets(10));
+    }
+
+    @Test
+    void testApplyStateCount0(){
+        applyState(generateRandomSubnets(0), generateRandomSubnets(0));
+    }
+
+    @Test
+    void testApplyStateNull(){
+        Assertions.assertThrows(NullPointerException.class, () -> applyState(null, null));
+    }
+
+    @Test
+    void testApplyStateNullBefore(){
+        Assertions.assertThrows(NullPointerException.class, () -> applyState(null, generateRandomSubnets(10)));
+    }
+
+    @Test
+    void testApplyStateNullAfter(){
+        Assertions.assertThrows(NullPointerException.class, () -> applyState(generateRandomSubnets(10), null));
+    }
+
+    @Test
+    void testApplyStateBeforeIncludeAfter(){
+        Set<Subnet> before = generateRandomSubnets(10);
+        Set<Subnet> after = new HashSet<>(before);
+        applyState(before, after);
+    }
+
+    @Test
+    void testApplyStateAfterIncludeBefore(){
+        Set<Subnet> after = generateRandomSubnets(10);
+        Set<Subnet> before = new HashSet<>(after);
+        applyState(before, after);
+    }
+}

--- a/src/test/java/com/wireguard/external/wireguard/SubnetServiceTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/SubnetServiceTest.java
@@ -3,15 +3,11 @@ package com.wireguard.external.wireguard;
 import com.wireguard.external.network.ISubnet;
 import com.wireguard.external.network.IV4SubnetSolver;
 import com.wireguard.external.network.Subnet;
-import com.wireguard.external.network.SubnetSolver;
 import com.wireguard.external.wireguard.peer.PeerCreationRules;
-import com.wireguard.external.wireguard.peer.WgPeer;
-import lombok.ToString;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.HashSet;

--- a/src/test/java/com/wireguard/external/wireguard/WgPeerServiceTest.java
+++ b/src/test/java/com/wireguard/external/wireguard/WgPeerServiceTest.java
@@ -1,8 +1,6 @@
 package com.wireguard.external.wireguard;
 
-import com.wireguard.external.network.ISubnet;
 import com.wireguard.external.network.Subnet;
-import com.wireguard.external.network.SubnetSolver;
 import com.wireguard.external.wireguard.peer.*;
 import com.wireguard.external.wireguard.peer.spec.FindByPublicKey;
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
Added point to update peer. You can now update a peer without having to delete it.
Example request (Fake data):
```bash
curl -X 'PATCH' \
  'http://localhost:8080/peer/update?publicKey=PubKey1&newPublicKey=newPubKey&presharedKey=NewPSK&endpoint=111.111.111.111%3A8011&allowedIps=10.0.5.55%2F30%2Cfd46%3A2d21%3A6f60%3A8e9f%3A%3A%2F64&persistentKeepalive=25' \
  -H 'accept: */*'
```
Responce:
```json
{
  "publicKey": "newPubKey",
  "presharedKey": "NewPSK",
  "endpoint": "111.111.111.111:8011",
  "allowedSubnets": [
    "fd46:2d21:6f60:8e9f::/64",
    "10.0.5.55/30"
  ],
  "latestHandshake": 0,
  "transferRx": 0,
  "transferTx": 0,
  "persistentKeepalive": 25
}
```
