### PR TITLE
Created endpoint with statistics of service

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ All parameters that are set as an example are the default values
 ### Get all peers:
 ```shell
 curl -X 'GET' \
-  'http://localhost:8080/v1/peers?limit=1' \
+  'http://localhost:8081/v1/peers?limit=1' \
   -H 'accept: application/json'
 ```
 ```json
@@ -81,7 +81,7 @@ curl -X 'GET' \
 ### Create peer automatically:
 ```shell
 curl -X 'POST' \
-  'http://localhost:8080/v1/peers' \
+  'http://localhost:8081/v1/peers' \
   -H 'accept: application/json'
 ```
 ```json
@@ -99,7 +99,7 @@ curl -X 'POST' \
 ### Create peer with custom parameters:
 ```shell
 curl -X 'POST' \
-  'http://localhost:8080/v1/peers?publicKey=RmFrZVBydktleUZha2VQcnZLZXkgICAgICAyMDAxNQ%3D%3D&presharedKey=RmFrZVBza0tleUZha2VQc2tLZXkgICAgICAyMDAxNw%3D%3D&privateKey=cHViREF4TlE9PUZha2VQdWJLZXkgICAgICAyMDAxNg%3D%3D&allowedIps=10.0.0.32%2F32&allowedIps=2002%3A0%3A0%3A1234%3A%3A%2F64&persistentKeepalive=25' \
+  'http://localhost:8081/v1/peers?publicKey=RmFrZVBydktleUZha2VQcnZLZXkgICAgICAyMDAxNQ%3D%3D&presharedKey=RmFrZVBza0tleUZha2VQc2tLZXkgICAgICAyMDAxNw%3D%3D&privateKey=cHViREF4TlE9PUZha2VQdWJLZXkgICAgICAyMDAxNg%3D%3D&allowedIps=10.0.0.32%2F32&allowedIps=2002%3A0%3A0%3A1234%3A%3A%2F64&persistentKeepalive=25' \
   -H 'accept: application/json'
 ````
 ```json
@@ -118,7 +118,7 @@ curl -X 'POST' \
 #### Delete peer:
 ```shell
 curl -X 'DELETE' \
-  'http://localhost:8080/v1/peers?publicKey=AhM4WLR7ETzLYDQ0zEq%2F0pvbYAxsbLwzzlIAdWhR7yg%3D' \
+  'http://localhost:8081/v1/peers?publicKey=AhM4WLR7ETzLYDQ0zEq%2F0pvbYAxsbLwzzlIAdWhR7yg%3D' \
   -H 'accept: application/json'
   ```
 ```json
@@ -140,7 +140,7 @@ curl -X 'DELETE' \
 #### Update peer:
 ```shell
 curl -X 'PATCH' \
-  'http://localhost:8080/v1/peers?publicKey=cHViREF4T0E9PUZha2VQdWJLZXkgICAgICAyMDAxOQ%3D%3D&presharedKey=%2BEWn9NeR2pVuFHihYMC6LKreccd5VIW4prUkzHLy0nw%3D' \
+  'http://localhost:8081/v1/peers?publicKey=cHViREF4T0E9PUZha2VQdWJLZXkgICAgICAyMDAxOQ%3D%3D&presharedKey=%2BEWn9NeR2pVuFHihYMC6LKreccd5VIW4prUkzHLy0nw%3D' \
   -H 'accept: application/json'
   ```
 ```json
@@ -161,7 +161,7 @@ curl -X 'PATCH' \
 #### Get peer by public key:
 ```shell
 curl -X 'GET' \
-  'http://localhost:8080/v1/peers/find?publicKey=cHViREF4T0E9PUZha2VQdWJLZXkgICAgICAyMDAxOQ%3D%3D' \
+  'http://localhost:8081/v1/peers/find?publicKey=cHViREF4T0E9PUZha2VQdWJLZXkgICAgICAyMDAxOQ%3D%3D' \
   -H 'accept: application/json'
   ```
 ```json
@@ -181,7 +181,7 @@ curl -X 'GET' \
 ---
 ```shell
 curl -X 'GET' \
-  'http://localhost:8080/v1/interface' \
+  'http://localhost:8081/v1/interface' \
   -H 'accept: application/json'
 ```
 ```json
@@ -197,7 +197,7 @@ curl -X 'GET' \
 #### Get logs of service:
 ```shell
 curl -X 'GET' \
-  'http://localhost:8080/v1/service/logs?from=0&limit=100' \
+  'http://localhost:8081/v1/service/logs?from=0&limit=100' \
   -H 'accept: application/json'
   ````
 ```json

--- a/src/main/java/com/wirerest/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/wirerest/api/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.wirerest.network.AlreadyUsedException;
 import com.wirerest.shell.CommandExecutionException;
 import com.wirerest.wireguard.ParsingException;
 import com.wirerest.wireguard.peer.PeerAlreadyExistsException;
+import com.wirerest.wireguard.peer.PeerNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +28,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<AppError> catchResourceNotFoundException(ResourceNotFoundException e) {
+        logger.error(e.getMessage(), e);
+        return getAppErrorResponseEntity(HttpStatus.NOT_FOUND, e);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<AppError> catchPeerNotFoundException(PeerNotFoundException e) {
         logger.error(e.getMessage(), e);
         return getAppErrorResponseEntity(HttpStatus.NOT_FOUND, e);
     }

--- a/src/main/java/com/wirerest/api/OpenAPIConfigurator.java
+++ b/src/main/java/com/wirerest/api/OpenAPIConfigurator.java
@@ -4,6 +4,7 @@ import com.wirerest.api.dto.PageDTO;
 import com.wirerest.api.inteface.WgInterfaceDTO;
 import com.wirerest.api.peer.CreatedPeerDTO;
 import com.wirerest.api.peer.WgPeerDTO;
+import com.wirerest.api.service.StatsSnapshotDto;
 import com.wirerest.logs.LoggingEventDto;
 import com.wirerest.network.AlreadyUsedException;
 import com.wirerest.network.Subnet;
@@ -232,6 +233,13 @@ public class OpenAPIConfigurator {
         AlreadyUsedException alreadyUsedException = new AlreadyUsedException(Subnet.valueOf("10.0.0.100/32"));
         addError("alreadyUsed409", "Already used", 409,
                 alreadyUsedException.getMessage());
+    }
+
+    @PostConstruct
+    public void stats() {
+        StatsSnapshotDto statsSnapshotDto = new StatsSnapshotDto(1691322509881L, 50208,
+                65536, 9562, 299314471044L, 300455868743L);
+        addObject("stats", "Stats", statsSnapshotDto);
     }
 
 }

--- a/src/main/java/com/wirerest/api/converters/StatsSnapshotToDtoConverter.java
+++ b/src/main/java/com/wirerest/api/converters/StatsSnapshotToDtoConverter.java
@@ -1,0 +1,19 @@
+package com.wirerest.api.converters;
+
+import com.wirerest.api.service.StatsSnapshotDto;
+import com.wirerest.stats.StatsSnapshot;
+import org.springframework.core.convert.converter.Converter;
+
+public class StatsSnapshotToDtoConverter implements Converter<StatsSnapshot, StatsSnapshotDto> {
+    @Override
+    public StatsSnapshotDto convert(StatsSnapshot source) {
+        return new StatsSnapshotDto(
+                source.getTimestamp().toEpochMilli(),
+                source.getTotalPeers(),
+                source.getTotalV4Ips(),
+                source.getFreeV4Ips(),
+                source.getTransferTxTotal(),
+                source.getTransferRxTotal()
+        );
+    }
+}

--- a/src/main/java/com/wirerest/api/service/StatsController.java
+++ b/src/main/java/com/wirerest/api/service/StatsController.java
@@ -1,9 +1,17 @@
 package com.wirerest.api.service;
 
+import com.wirerest.api.AppError;
 import com.wirerest.api.converters.StatsSnapshotToDtoConverter;
+import com.wirerest.logs.LoggingEventDto;
 import com.wirerest.logs.LogsDao;
 import com.wirerest.stats.StatsService;
 import com.wirerest.stats.StatsSnapshot;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,9 +28,33 @@ public class StatsController {
         this.statsService = statsService;
     }
 
+    @Operation(summary = "Get application statistics",
+            description = """
+                    Timestamp - Unix milliseconds timestamp of the snapshot
+                                        
+                    peers - number of peers in the interface
+                    
+                    totalV4Ips - number of IPv4 addresses (/32) in the interface
+                    
+                    freeV4Ips - number of addresses (/32) that are not in use
+                    
+                    transferTx - total transmitted bytes for all peers
+                    
+                    transferRx - total received bytes for all peers""",
+            tags = {"Service"},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK",
+                            content = {@Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = StatsSnapshotDto.class)),
+                                    examples = {
+                                            @ExampleObject(name = "Stats",
+                                                    ref = "#/components/examples/stats")
+                                    })})
+            })
     @GetMapping("/v1/service/stats")
     public StatsSnapshotDto getStats() {
         return statsSnapshotToDtoConverter.convert(statsService.snapshot());
     }
+
 
 }

--- a/src/main/java/com/wirerest/api/service/StatsController.java
+++ b/src/main/java/com/wirerest/api/service/StatsController.java
@@ -1,0 +1,28 @@
+package com.wirerest.api.service;
+
+import com.wirerest.api.converters.StatsSnapshotToDtoConverter;
+import com.wirerest.logs.LogsDao;
+import com.wirerest.stats.StatsService;
+import com.wirerest.stats.StatsSnapshot;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+public class StatsController {
+
+    StatsService statsService;
+    StatsSnapshotToDtoConverter statsSnapshotToDtoConverter = new StatsSnapshotToDtoConverter();
+    @Autowired
+    public StatsController(StatsService statsService) {
+        this.statsService = statsService;
+    }
+
+    @GetMapping("/v1/service/stats")
+    public StatsSnapshotDto getStats() {
+        return statsSnapshotToDtoConverter.convert(statsService.snapshot());
+    }
+
+}

--- a/src/main/java/com/wirerest/api/service/StatsController.java
+++ b/src/main/java/com/wirerest/api/service/StatsController.java
@@ -30,7 +30,7 @@ public class StatsController {
 
     @Operation(summary = "Get application statistics",
             description = """
-                    Timestamp - Unix milliseconds timestamp of the snapshot
+                    Timestamp - Unix milliseconds timestamp of the stats snapshot
                                         
                     peers - number of peers in the interface
                     

--- a/src/main/java/com/wirerest/api/service/StatsSnapshotDto.java
+++ b/src/main/java/com/wirerest/api/service/StatsSnapshotDto.java
@@ -1,0 +1,16 @@
+package com.wirerest.api.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@AllArgsConstructor
+@Data
+public class StatsSnapshotDto {
+    private final long timestamp;
+    private final long peers;
+    private final long totalV4Ips;
+    private final long freeV4Ips;
+    private final long transferTx;
+    private final long transferRx;
+}

--- a/src/main/java/com/wirerest/stats/StatsService.java
+++ b/src/main/java/com/wirerest/stats/StatsService.java
@@ -1,0 +1,34 @@
+package com.wirerest.stats;
+
+import com.wirerest.network.IV4SubnetSolver;
+import com.wirerest.wireguard.SubnetService;
+import com.wirerest.wireguard.peer.WgPeer;
+import com.wirerest.wireguard.peer.WgPeerService;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+@Component
+public class StatsService {
+
+    IV4SubnetSolver subnetSolver;
+    WgPeerService wgPeerService;
+
+    public StatsService(IV4SubnetSolver subnetSolver, WgPeerService wgPeerService) {
+        this.subnetSolver = subnetSolver;
+        this.wgPeerService = wgPeerService;
+    }
+
+    public StatsSnapshot snapshot() {
+        List<WgPeer> peers = wgPeerService.getPeers();
+        return new StatsSnapshot.Builder()
+                .timestamp(Instant.now())
+                .freeV4Ips(subnetSolver.getAvailableIpsCount())
+                .totalV4Ips(subnetSolver.getTotalIpsCount())
+                .totalPeers(peers.size())
+                .transferRxTotal(peers.stream().mapToLong(WgPeer::getTransferRx).sum())
+                .transferTxTotal(peers.stream().mapToLong(WgPeer::getTransferTx).sum())
+                .build();
+    }
+}

--- a/src/main/java/com/wirerest/stats/StatsSnapshot.java
+++ b/src/main/java/com/wirerest/stats/StatsSnapshot.java
@@ -1,0 +1,62 @@
+package com.wirerest.stats;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+@Getter
+public class StatsSnapshot {
+    private final Instant timestamp;
+    private final long totalPeers;
+    private final long totalV4Ips;
+    private final long freeV4Ips;
+    private final long transferTxTotal;
+    private final long transferRxTotal;
+
+    public static class Builder{
+        private Instant timestamp;
+        private long totalPeers;
+        private long totalV4Ips;
+        private long freeV4Ips;
+        private long transferTxTotal;
+        private long transferRxTotal;
+
+        public Builder timestamp(Instant timestamp){
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        public Builder totalPeers(long totalPeers){
+            this.totalPeers = totalPeers;
+            return this;
+        }
+
+        public Builder totalV4Ips(long totalV4Ips){
+            this.totalV4Ips = totalV4Ips;
+            return this;
+        }
+
+        public Builder freeV4Ips(long freeV4Ips){
+            this.freeV4Ips = freeV4Ips;
+            return this;
+        }
+
+        public Builder transferTxTotal(long transferTxTotal){
+            this.transferTxTotal = transferTxTotal;
+            return this;
+        }
+
+        public Builder transferRxTotal(long transferRxTotal){
+            this.transferRxTotal = transferRxTotal;
+            return this;
+        }
+
+        public StatsSnapshot build(){
+            return new StatsSnapshot(timestamp, totalPeers, totalV4Ips, freeV4Ips, transferTxTotal, transferRxTotal);
+        }
+
+    }
+}

--- a/src/main/java/com/wirerest/wireguard/SubnetService.java
+++ b/src/main/java/com/wirerest/wireguard/SubnetService.java
@@ -21,8 +21,8 @@ import java.util.function.Consumer;
 public class SubnetService {
 
     private static final Logger logger = LoggerFactory.getLogger(SubnetService.class);
-    PeerCreationRules peerCreationRules;
-    IV4SubnetSolver v4SubnetSolver;
+    private final PeerCreationRules peerCreationRules;
+    private final IV4SubnetSolver v4SubnetSolver;
 
     @Autowired
     public SubnetService(PeerCreationRules peerCreationRules, IV4SubnetSolver v4SubnetSolver) {

--- a/src/main/java/com/wirerest/wireguard/peer/PeerNotFoundException.java
+++ b/src/main/java/com/wirerest/wireguard/peer/PeerNotFoundException.java
@@ -1,8 +1,9 @@
 package com.wirerest.wireguard.peer;
 
-import com.wirerest.api.ResourceNotFoundException;
 
-public class PeerNotFoundException extends ResourceNotFoundException {
+import org.webjars.NotFoundException;
+
+public class PeerNotFoundException extends NotFoundException {
     public PeerNotFoundException(String publicKey) {
         super("Peer with public key %s not found".formatted(publicKey));
     }

--- a/src/main/java/com/wirerest/wireguard/peer/WgPeerService.java
+++ b/src/main/java/com/wirerest/wireguard/peer/WgPeerService.java
@@ -31,10 +31,11 @@ import static com.wirerest.utils.AsyncUtils.await;
 public class WgPeerService {
 
     private static final Logger logger = LoggerFactory.getLogger(WgPeerService.class);
-    WgPeerGenerator peerGenerator;
-    RepositoryPageable<WgPeer> wgPeerRepository;
-    SubnetService subnetService;
-    BlockingByHashAsyncExecutor<WgPeer> blockingByHashAsyncExecutor = new BlockingByHashAsyncExecutor<>();
+    private final WgPeerGenerator peerGenerator;
+    private final RepositoryPageable<WgPeer> wgPeerRepository;
+    private final SubnetService subnetService;
+    private final BlockingByHashAsyncExecutor<WgPeer> blockingByHashAsyncExecutor = new BlockingByHashAsyncExecutor<>();
+
 
 
     @Autowired

--- a/src/main/java/com/wirerest/wireguard/test/FakeWgTool.java
+++ b/src/main/java/com/wirerest/wireguard/test/FakeWgTool.java
@@ -10,10 +10,7 @@ import lombok.SneakyThrows;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @Profile("test")
 @Component
@@ -39,9 +36,13 @@ public class FakeWgTool extends WgTool {
                 WgPeer.publicKey(genPubKey()).presharedKey(generatePresharedKey()).allowedIps(Set.of(Subnet.valueOf("10.0.0.7/32"), SubnetV6.valueOf("::1/128")))
                         .latestHandshake(200000).transferRx(12345).transferTx(54321).build()
         ).forEach(peer -> peers.put(peer.getPublicKey(), peer));
-        for (int i = 0; i < 20000; i++) {
+        Random random = new Random();
+        for (int i = 0; i < 60000; i++) {
             String pubkey = genPubKey();
-            peers.put(pubkey, WgPeer.publicKey(pubkey).presharedKey(generatePresharedKey()).build());
+            peers.put(pubkey, WgPeer.publicKey(pubkey).presharedKey(generatePresharedKey())
+                    .transferRx(random.nextInt(10000000))
+                    .transferTx(random.nextInt(10000000))
+                    .build());
         }
         keyCounter = peers.size() + 1;
     }


### PR DESCRIPTION
GET request to /v1/service/stats returns general information about service 
request
```
curl -X 'GET' \
  'http://localhost:8081/v1/service/stats' \
  -H 'accept: application/json'
```
Responce
```json
{
  "timestamp": 1692365800425,
  "peers": 60008,
  "totalV4Ips": 65536,
  "freeV4Ips": 65527,
  "transferTx": 300879237901,
  "transferRx": 301434168153
}
```

Timestamp - Unix milliseconds timestamp of the snapshot

peers - number of peers in the interface

totalV4Ips - number of IPv4 addresses (/32) in the interface

freeV4Ips - number of addresses (/32) that are not in use

transferTx - total transmitted bytes for all peers

transferRx - total received bytes for all peers
